### PR TITLE
Adds necessary logic / endpoint to support "jump to definition" in jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ publishing {
 
 dependencies {
     implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.9.0"
-    implementation "software.amazon.smithy:smithy-model:1.5.1"
+    implementation "software.amazon.smithy:smithy-model:1.+"
 
     // Use JUnit test framework
     testImplementation "junit:junit:4.13"

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ publishing {
 
 dependencies {
     implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.9.0"
-    implementation "software.amazon.smithy:smithy-model:1.1.0"
+    implementation "software.amazon.smithy:smithy-model:1.5.1"
 
     // Use JUnit test framework
     testImplementation "junit:junit:4.13"

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ publishing {
 
 dependencies {
     implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.9.0"
-    implementation "software.amazon.smithy:smithy-model:1.+"
+    implementation "software.amazon.smithy:smithy-model:[1.0, 2.0["
 
     // Use JUnit test framework
     testImplementation "junit:junit:4.13"

--- a/src/main/java/software/amazon/smithy/lsp/SmithyKeywords.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyKeywords.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public final class SmithyKeywords {
   public static final List<String> BUILT_IN_TYPES = Arrays.asList("Blob", "Boolean", "String", "Byte", "Short",
-          "Integer", "Long", "Float", "Double", "BigInteger", "BigDecimal", "Timestamp", "Document");
+      "Integer", "Long", "Float", "Double", "BigInteger", "BigDecimal", "Timestamp", "Document");
   public static final List<String> KEYWORDS = Arrays.asList("bigDecimal", "bigInteger", "blob", "boolean", "byte",
       "document", "double", "errors", "float", "input", "integer", "integer", "list", "long", "map", "metadata",
       "namespace", "operation", "output", "resource", "service", "set", "short", "string", "structure", "timestamp",

--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -16,9 +16,11 @@
 package software.amazon.smithy.lsp;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
@@ -26,6 +28,7 @@ import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
@@ -33,7 +36,7 @@ import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
-public class SmithyLanguageServer implements LanguageServer, LanguageClientAware {
+public class SmithyLanguageServer implements LanguageServer, LanguageClientAware, SmithyProtocolExtensions {
 
   private Optional<LanguageClient> client = Optional.empty();
 
@@ -72,7 +75,6 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
 
   }
 
-
   @Override
   public WorkspaceService getWorkspaceService() {
     // TODO Auto-generated method stub
@@ -93,6 +95,19 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
     }
 
     client.showMessage(new MessageParams(MessageType.Info, "Hello from smithy-language-server !"));
+  }
+
+  @Override
+  public CompletableFuture<String> jarFileContents(TextDocumentIdentifier documentUri) {
+    try {
+      java.util.List<String> lines = Utils.jarFileContents(documentUri.getUri(), this.getClass().getClassLoader());
+      String contents = lines.stream().collect(Collectors.joining(System.lineSeparator()));
+      return CompletableFuture.completedFuture(contents);
+    } catch (IOException e) {
+      CompletableFuture<String> future = new CompletableFuture<String>();
+      future.completeExceptionally(e);
+      return future;
+    }
   }
 
 }

--- a/src/main/java/software/amazon/smithy/lsp/SmithyProtocolExtensions.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyProtocolExtensions.java
@@ -1,0 +1,18 @@
+package software.amazon.smithy.lsp;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
+
+/**
+ * Interface for protocol extensions for Smithy
+ */
+@JsonSegment("smithy")
+public interface SmithyProtocolExtensions {
+
+  @JsonRequest
+  CompletableFuture<String> jarFileContents(TextDocumentIdentifier documentUri);
+
+}

--- a/src/main/java/software/amazon/smithy/lsp/SmithyProtocolExtensions.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyProtocolExtensions.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package software.amazon.smithy.lsp;
 
 import java.util.concurrent.CompletableFuture;

--- a/src/main/java/software/amazon/smithy/lsp/SmithyProtocolExtensions.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyProtocolExtensions.java
@@ -22,7 +22,7 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
 
 /**
- * Interface for protocol extensions for Smithy
+ * Interface for protocol extensions for Smithy.
  */
 @JsonSegment("smithy")
 public interface SmithyProtocolExtensions {

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -251,8 +251,8 @@ public class SmithyTextDocumentService implements TextDocumentService {
       String uri = sourceLocation.getFilename();
       if (uri.startsWith("jar:file:")) {
         uri = "smithyjar:" + uri.substring(9);
-      } else if (uri.startsWith("file:")) {
-        uri = uri.substring(5);
+      } else if (!uri.startsWith("file:")) {
+        uri = "file:" + uri;
       }
       Position pos = new Position(sourceLocation.getLine() - 1, sourceLocation.getColumn() - 1);
       Location location = new Location(uri, new Range(pos, pos));

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -243,7 +243,6 @@ public class SmithyTextDocumentService implements TextDocumentService {
 
   /**
    *
-   * @param uri   URI to set updated locations.
    * @param model Model to get source locations of shapes.
    */
   public void updateLocations(Model model) {

--- a/src/main/java/software/amazon/smithy/lsp/Utils.java
+++ b/src/main/java/software/amazon/smithy/lsp/Utils.java
@@ -75,7 +75,7 @@ public final class Utils {
   /**
    * @param rawUri the uri to a file in a jar.
    * @param classLoader a classloader used to retrieve resources.
-   * @return
+   * @return the lines of the jar file, as a list.
    * @throws IOException when rawUri cannot be URI-decoded.
    */
   public static List<String> jarFileContents(String rawUri, ClassLoader classLoader) throws IOException {

--- a/src/main/java/software/amazon/smithy/lsp/Utils.java
+++ b/src/main/java/software/amazon/smithy/lsp/Utils.java
@@ -45,6 +45,10 @@ public final class Utils {
     return CompletableFuture.supplyAsync(supplier);
   }
 
+  /**
+   * @param rawUri String
+   * @return Returns whether the uri points to a file in jar.
+   */
   public static boolean isSmithyJarFile(String rawUri) throws IOException {
     try {
       String uri = java.net.URLDecoder.decode(rawUri, StandardCharsets.UTF_8.name());
@@ -54,6 +58,11 @@ public final class Utils {
     }
   }
 
+  /**
+   * @param rawUri String
+   * @return Returns whether the uri points to a file in the filesystem (as
+   *         opposed to a file in a jar).
+   */
   public static boolean isFile(String rawUri) {
     try {
       String uri = java.net.URLDecoder.decode(rawUri, StandardCharsets.UTF_8.name());
@@ -63,6 +72,12 @@ public final class Utils {
     }
   }
 
+  /**
+   * @param rawUri the uri to a file in a jar.
+   * @param classLoader a classloader used to retrieve resources.
+   * @return
+   * @throws IOException when rawUri cannot be URI-decoded.
+   */
   public static List<String> jarFileContents(String rawUri, ClassLoader classLoader) throws IOException {
     String uri = java.net.URLDecoder.decode(rawUri, StandardCharsets.UTF_8.name());
     String[] pathArray = uri.split("!/");

--- a/src/main/java/software/amazon/smithy/lsp/Utils.java
+++ b/src/main/java/software/amazon/smithy/lsp/Utils.java
@@ -45,7 +45,7 @@ public final class Utils {
     return CompletableFuture.supplyAsync(supplier);
   }
 
-  public static Boolean isSmithyJarFile(String rawUri) throws IOException {
+  public static boolean isSmithyJarFile(String rawUri) throws IOException {
     try {
       String uri = java.net.URLDecoder.decode(rawUri, StandardCharsets.UTF_8.name());
       return uri.startsWith("smithyjar:");
@@ -54,7 +54,7 @@ public final class Utils {
     }
   }
 
-  public static Boolean isFile(String rawUri) {
+  public static boolean isFile(String rawUri) {
     try {
       String uri = java.net.URLDecoder.decode(rawUri, StandardCharsets.UTF_8.name());
       return uri.startsWith("file:");
@@ -64,22 +64,21 @@ public final class Utils {
   }
 
   public static List<String> jarFileContents(String rawUri, ClassLoader classLoader) throws IOException {
-    if (Utils.isSmithyJarFile(rawUri)) {
-      String uri = java.net.URLDecoder.decode(rawUri, StandardCharsets.UTF_8.name());
-      String[] pathArray = uri.split("!/");
-      String resourcePath = pathArray[1];
-      InputStream is = classLoader.getResourceAsStream(resourcePath);
-      try {
-        if (is != null) {
-          InputStreamReader isr = new InputStreamReader(is);
-          BufferedReader reader = new BufferedReader(isr);
-          return reader.lines().collect(Collectors.toList());
-        }
-      } finally {
-        is.close();
+    String uri = java.net.URLDecoder.decode(rawUri, StandardCharsets.UTF_8.name());
+    String[] pathArray = uri.split("!/");
+    String resourcePath = pathArray[1];
+    InputStream is = classLoader.getResourceAsStream(resourcePath);
+    List<String> result = null;
+    try {
+      if (is != null) {
+        InputStreamReader isr = new InputStreamReader(is);
+        BufferedReader reader = new BufferedReader(isr);
+        result = reader.lines().collect(Collectors.toList());
       }
+    } finally {
+      is.close();
     }
-    return null;
+    return result;
   }
 
 }


### PR DESCRIPTION
This adds logic to allow for navigating through definitions that are contained in jars. 

The way it works is by :
* introducing a "smithyjar" URI scheme that is used to discriminate between model files that are available on the FS, and ones that are present in jars. 
* transforming from the "jar:file" scheme returned by the smithy parser into "smithyjar", in order to avoid colliding with other tools that might handle "jar:file". 
* a "smithy/jarFileContents" LSP endpoint that can be called from text editors when they encounter "smithyjar". Now this endpoint is useful for vscode, as it doesn't as of now handles zipped files automatically, but it is really easy to add a "content provider" tied to the "smithyjar" scheme in a vscode extension, and have the provider call this endpoint to retrieve the content of the jars. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
