### PR TITLE
Add lsp4j license attribution

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,19 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+
+**********************
+THIRD PARTY COMPONENTS
+**********************
+
+This software includes third party software subject to the following copyrights:
+- lsp4j v0.9.0 - Copyright © 2007-2019 Eclipse Foundation, Inc. and its licensors. (Eclipse Distribution License - v2.0)
+
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0 which is available at
+      http://www.eclipse.org/legal/epl-2.0,
+      or the Eclipse Distribution License v. 1.0 which is available at
+      http://www.eclipse.org/org/documents/edl-v10.php.
+
+      SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+      https://github.com/eclipse/lsp4j/archive/v0.9.0.zip


### PR DESCRIPTION
Adds license attribution for use of lsp4j

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
