### PR TITLE
Use System IO by configuration

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/Main.java
+++ b/src/main/java/software/amazon/smithy/lsp/Main.java
@@ -35,13 +35,20 @@ public class Main {
   public static void main(String[] args) {
 
     Socket socket = null;
+    InputStream in;
+    OutputStream out;
 
     try {
       String port = args[0];
-      socket = new Socket("localhost", Integer.parseInt(port));
-
-      InputStream in = socket.getInputStream();
-      OutputStream out = socket.getOutputStream();
+      // If port is set to "0", use System.in/System.out.
+      if (port.equals("0")) {
+        in = System.in;
+        out = System.out;
+      } else {
+        socket = new Socket("localhost", Integer.parseInt(port));
+        in = socket.getInputStream();
+        out = socket.getOutputStream();
+      }
       SmithyLanguageServer server = new SmithyLanguageServer();
       Launcher<LanguageClient> launcher = LSPLauncher.createServerLauncher(server, in, out);
       LanguageClient client = launcher.getRemoteProxy();
@@ -67,6 +74,5 @@ public class Main {
         System.out.println(e);
       }
     }
-
   }
 }

--- a/src/test/java/software/amazon/smithy/lsp/AppTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/AppTest.java
@@ -15,12 +15,38 @@
 
 package software.amazon.smithy.lsp;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 public class AppTest {
-    @Test public void testAppHasAGreeting() {
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+
+    @Before
+    public void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+    }
+
+    @After
+    public void tearDownStreams() {
+        System.setOut(originalOut);
+    }
+
+    @Test
+    public void testAppHasAGreeting() {
         Main classUnderTest = new Main();
         assertNotNull("app should have a greeting", classUnderTest.getGreeting());
+    }
+
+    @Test
+    public void canConfigureSystemIo() {
+        Main.main(new String[] { "0" } );
+        assertTrue(outContent.toString().contains("Hello from smithy-language-server"));
     }
 }


### PR DESCRIPTION
Allows configuring the language server to use `stdin` and `stdout` for communication with the client by setting the port argument to `0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
