### PR TITLE
Add support for multi-file models

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ publishing {
 dependencies {
     implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.9.0"
     implementation "software.amazon.smithy:smithy-model:[1.0, 2.0["
+    implementation "commons-io:commons-io:2.6"
 
     // Use JUnit test framework
     testImplementation "junit:junit:4.13"

--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -54,6 +54,7 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
     if (params.getRootUri() != null) {
       try {
         workspaceRoot = new File(new URI(params.getRootUri()));
+        tds.setWorkspaceRoot(workspaceRoot);
       } catch (Exception e) {
         // TODO: handle exception
       }

--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -65,6 +65,7 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
     capabilities.setDefinitionProvider(true);
     capabilities.setDeclarationProvider(true);
     capabilities.setCompletionProvider(new CompletionOptions(true, null));
+    capabilities.setHoverProvider(false);
 
     return Utils.completableFuture(new InitializeResult(capabilities));
   }

--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
@@ -111,5 +110,4 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
       return future;
     }
   }
-
 }

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -62,6 +62,7 @@ public class SmithyTextDocumentService implements TextDocumentService {
   private Optional<LanguageClient> client = Optional.empty();
   private Map<String, List<? extends Location>> locations = new HashMap<String, List<? extends Location>>();
   private List<? extends Location> noLocations = Arrays.asList();
+  private File workspaceRoot;
 
   /**
    * @param client Language Client to be used by text document service.
@@ -81,6 +82,10 @@ public class SmithyTextDocumentService implements TextDocumentService {
 
   public void setClient(LanguageClient client) {
     this.client = Optional.of(client);
+  }
+
+  public void setWorkspaceRoot(File workspaceRoot) {
+    this.workspaceRoot = workspaceRoot;
   }
 
   private MessageParams msg(final MessageType sev, final String cont) {

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -246,7 +246,10 @@ public class SmithyTextDocumentService implements TextDocumentService {
    * @param model Model to get source locations of shapes.
    */
   public void updateLocations(Model model) {
-    model.shapes().forEach(shape -> {
+    model.shapes()
+            // Filter member shapes to avoid polluting the locations map keys.
+            .filter(shape -> !shape.isMemberShape())
+            .forEach(shape -> {
       SourceLocation sourceLocation = shape.getSourceLocation();
       String uri = sourceLocation.getFilename();
       if (uri.startsWith("jar:file:")) {


### PR DESCRIPTION
Closes #11 

Adds support for multi-file models.

When compiling a model, all Smithy model files within the workspace are pulled into the model assembler.  Any files in the `/build` directory are excluded to prevent artifacts from prior builds being included and causing duplication.

With this change, go-to-definition works across multiple files, as does validation of models that span multiple input files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
