### PR TITLE
Upgrade to Gradle 6.8.3

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -15,8 +15,8 @@
   -->
 
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
     <module name="SuppressWarningsFilter" />
@@ -80,10 +80,8 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MissingJavadocMethod">
             <property name="minLineCount" value="2"/>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/software/amazon/smithy/lsp/Main.java
+++ b/src/main/java/software/amazon/smithy/lsp/Main.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.lsp;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
-
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.launch.LSPLauncher;
 import org.eclipse.lsp4j.services.LanguageClient;

--- a/src/main/java/software/amazon/smithy/lsp/ProtocolAdapter.java
+++ b/src/main/java/software/amazon/smithy/lsp/ProtocolAdapter.java
@@ -19,7 +19,6 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
-
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidationEvent;
 

--- a/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
@@ -16,9 +16,7 @@
 package software.amazon.smithy.lsp;
 
 import java.io.File;
-
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.validation.ValidatedResult;
 

--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;

--- a/src/main/java/software/amazon/smithy/lsp/SmithyProtocolExtensions.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyProtocolExtensions.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.lsp;
 
 import java.util.concurrent.CompletableFuture;
-
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.CompletionList;
@@ -50,7 +49,6 @@ import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
-
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.SourceLocation;
 import software.amazon.smithy.model.validation.ValidatedResult;


### PR DESCRIPTION
This PR upgrades Gradle to 6.8.3.

This upgrade required updating checkstyle, which now matches the main Smithy [repository](https://github.com/awslabs/smithy).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
