### PR TITLE
Set hover provider capability

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -64,6 +64,7 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
     capabilities.setDefinitionProvider(true);
     capabilities.setDeclarationProvider(true);
     capabilities.setCompletionProvider(new CompletionOptions(true, null));
+    capabilities.setHoverProvider(false);
 
     return Utils.completableFuture(new InitializeResult(capabilities));
   }


### PR DESCRIPTION
This resolves an issue for some LSP clients, including [Smithy Intellij](https://github.com/awslabs/smithy-intellij). Those LSP clients will emit warnings and potentially crash if the hover provider is unset, resulting an a NullPointerException when the client attempts to check the server's capabilities.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
