### PR TITLE
Set diagnostics to entire line

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/ProtocolAdapter.java
+++ b/src/main/java/software/amazon/smithy/lsp/ProtocolAdapter.java
@@ -37,7 +37,7 @@ public final class ProtocolAdapter {
 
     DiagnosticSeverity severity = toDiagnosticSeverity(event.getSeverity());
 
-    Range range = new Range(new Position(line, col), new Position(line, col));
+    Range range = new Range(new Position(line, 0), new Position(line, col));
 
     return new Diagnostic(range, event.getMessage(), severity, "Smithy LSP");
   }


### PR DESCRIPTION
This resolves an issue on smithy-intellij where diagnostic position ranges are of zero-length, causing lsp4intellij to emit validation warnings and diagnostic failures are not rendered as a result.

This updates the diagnostics to be set to the entire line of the model.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
