### PR TITLE
Remove deprecated jcenter repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@
 
 buildscript {
   repositories {
-    jcenter()
     maven { url "https://plugins.gradle.org/m2/" }
     mavenLocal()
   }
@@ -46,9 +45,8 @@ allprojects {
 }
 
 repositories {
-    // Use jcenter for resolving dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    mavenLocal()
+    mavenCentral()
 }
 
 publishing {


### PR DESCRIPTION
Removes the deprecated jcenter repository.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
