### PR TITLE
Fix copyright year and import order

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -31,7 +31,7 @@
     <!-- Files must contain a copyright header. -->
     <module name="RegexpHeader">
         <property name="header"
-                  value="/\*\n \* Copyright 202(0|1) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
+                  value="/\*\n \* Copyright 202\d Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/src/main/java/software/amazon/smithy/lsp/ext/Completions.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/Completions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/amazon/smithy/lsp/ext/Constants.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/amazon/smithy/lsp/ext/DependencyDownloader.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/DependencyDownloader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/amazon/smithy/lsp/ext/Document.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/Document.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/amazon/smithy/lsp/ext/DocumentPreamble.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/DocumentPreamble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyBuildExtensions.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyBuildExtensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyBuildLoader.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyBuildLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyCompletionItem.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyCompletionItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/software/amazon/smithy/lsp/ext/ValidationException.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/ValidationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/software/amazon/smithy/lsp/ext/CompletionTests.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/CompletionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,20 +15,17 @@
 
 package software.amazon.smithy.lsp.ext;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.eclipse.lsp4j.CompletionItem;
+import org.junit.Test;
+import software.amazon.smithy.utils.MapUtils;
+import software.amazon.smithy.utils.SetUtils;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.eclipse.lsp4j.CompletionItem;
-import org.junit.Test;
-
-import software.amazon.smithy.utils.MapUtils;
-import software.amazon.smithy.utils.SetUtils;
+import static org.junit.Assert.assertEquals;
 
 public class CompletionTests {
 

--- a/src/test/java/software/amazon/smithy/lsp/ext/Harness.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/Harness.java
@@ -1,4 +1,22 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package software.amazon.smithy.lsp.ext;
+
+import com.google.common.io.Files;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -7,10 +25,6 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
-import com.google.common.io.Files;
-
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 public class Harness implements AutoCloseable {
   private File root;

--- a/src/test/java/software/amazon/smithy/lsp/ext/ProtocolAdapterTests.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/ProtocolAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 package software.amazon.smithy.lsp;
 
 import org.eclipse.lsp4j.Diagnostic;
-import static software.amazon.smithy.model.validation.Severity.WARNING;
+import org.junit.Test;
 import software.amazon.smithy.model.validation.ValidationEvent;
 
 import static org.junit.Assert.assertEquals;
-import org.junit.Test;
+import static software.amazon.smithy.model.validation.Severity.WARNING;
 
 public class ProtocolAdapterTests {
 	@Test

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyBuildExtensionsTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyBuildExtensionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,16 +15,15 @@
 
 package software.amazon.smithy.lsp.ext;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
-import com.google.common.collect.ImmutableList;
-
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class SmithyBuildExtensionsTest {
 

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@
 
 package software.amazon.smithy.lsp.ext;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import software.amazon.smithy.utils.ListUtils;
+import software.amazon.smithy.utils.MapUtils;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -25,10 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
-
-import software.amazon.smithy.utils.ListUtils;
-import software.amazon.smithy.utils.MapUtils;
+import static org.junit.Assert.assertEquals;
 
 public class SmithyProjectTest {
 

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -15,18 +15,6 @@
 
 package software.amazon.smithy.lsp.ext;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
@@ -41,11 +29,22 @@ import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.junit.Test;
-
 import software.amazon.smithy.lsp.SmithyTextDocumentService;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 import software.amazon.smithy.utils.SetUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
 
 public class SmithyTextDocumentServiceTest {
 


### PR DESCRIPTION
Updates checkstyle configuration to allow for 2022 copyright year and updates recently contributed files. Also re-orders imports to pass checkstyle.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
