### PR TITLE
Determine end of definition location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ bin
 
 .java-version
 *.smithy
+!/src/test/resources/**/*.smithy
 .ammonite

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -206,7 +206,11 @@ public class SmithyTextDocumentService implements TextDocumentService {
                 LspLog.println("Path " + path + " was found in temporary buffer");
                 contents = Arrays.stream(tempContents.split("\n")).collect(Collectors.toList());
             } else {
-                contents = readAll(new File(URI.create(path)));
+                try {
+                    contents = readAll(new File(URI.create(path)));
+                } catch (IllegalArgumentException e) {
+                    contents = readAll(new File(path));
+                }
             }
 
         }
@@ -356,7 +360,11 @@ public class SmithyTextDocumentService implements TextDocumentService {
     }
 
     private File fileFromUri(String uri) {
-        return new File(URI.create(uri));
+        try {
+            return new File(URI.create(uri));
+        } catch (IllegalArgumentException e) {
+            return new File(uri);
+        }
     }
 
     /**

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -235,7 +235,7 @@ public final class SmithyProject {
     private static List<String> getFileLines(String file) {
         try {
             if (Utils.isSmithyJarFile(file) || Utils.isJarFile(file)) {
-                return Utils.jarFileContents(file);
+                return Utils.jarFileContents(Utils.toSmithyJarFile(file));
             } else {
                 return Files.readAllLines(Paths.get(file));
             }

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -165,8 +165,7 @@ public final class SmithyProject {
                 .distinct()
                 .collect(Collectors.toList());
         for (String modelFile : modelFiles) {
-            Path modelPath = Paths.get(modelFile);
-            List<String> lines = getFileLines(modelPath);
+            List<String> lines = getFileLines(modelFile);
             int endMarker = lines.size();
 
             // Get shapes reverse-sorted by source location to work from bottom of file to top.
@@ -213,14 +212,15 @@ public final class SmithyProject {
         return locations;
     }
 
-    private static List<String> getFileLines(Path path) {
+    private static List<String> getFileLines(String file) {
         try {
-            if (Utils.isSmithyJarFile(path.toString())) {
-                return Utils.jarFileContents(path.toString());
+            if (Utils.isSmithyJarFile(file) || Utils.isJarFile(file)) {
+                return Utils.jarFileContents(file);
+            } else {
+                return Files.readAllLines(Paths.get(file));
             }
-            return Files.readAllLines(path);
         } catch (IOException e) {
-            LspLog.println("Path " + path + " was found in temporary buffer");
+            LspLog.println("File " + file + " could not be loaded.");
         }
         return Collections.emptyList();
     }

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.lsp4j.Location;
@@ -254,29 +253,26 @@ public final class SmithyProject {
 
         return locations.entrySet().stream()
                 .filter(entry -> entry.getValue().getUri().endsWith(Paths.get(uri).toString()))
-                .filter(filterByLocation(position))
+                .filter(entry -> isPositionInRange(entry.getValue().getRange(), position))
                 // Since the position is in each of the overlapping shapes, return the location with the smallest range.
                 .sorted(rangeSize)
                 .map(entry -> entry.getKey())
                 .findFirst();
     }
 
-    private Predicate<Map.Entry<ShapeId, Location>> filterByLocation(Position position) {
-        return entry -> {
-            Range range = entry.getValue().getRange();
-            if (range.getStart().getLine() > position.getLine()) {
-                return false;
-            }
-            if (range.getEnd().getLine() < position.getLine()) {
-                return false;
-            }
-            if (range.getStart().getLine() == position.getLine()) {
-                return range.getStart().getCharacter() <= position.getCharacter();
-            } else if (range.getEnd().getLine() == position.getLine()) {
-                return range.getEnd().getCharacter() >= position.getCharacter();
-            }
-            return true;
-        };
+    private boolean isPositionInRange(Range range, Position position) {
+        if (range.getStart().getLine() > position.getLine()) {
+            return false;
+        }
+        if (range.getEnd().getLine() < position.getLine()) {
+            return false;
+        }
+        if (range.getStart().getLine() == position.getLine()) {
+            return range.getStart().getCharacter() <= position.getCharacter();
+        } else if (range.getEnd().getLine() == position.getLine()) {
+            return range.getEnd().getCharacter() >= position.getCharacter();
+        }
+        return true;
     }
 
     private static int getInitialEndMarker(List<String> lines) {

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -248,7 +248,7 @@ public final class SmithyProject {
                 entry.getValue().getRange().getEnd().getLine() - entry.getValue().getRange().getStart().getLine());
 
         List<Map.Entry<ShapeId, Location>> matchingShapes = locations.entrySet().stream()
-                .filter(entry -> Paths.get(entry.getValue().getUri()).equals(Paths.get(uri)))
+                .filter(entry -> entry.getValue().getUri().endsWith(Paths.get(uri).toString()))
                 .filter(filterByLocation(position))
                 // Since the position is in each of the overlapping shapes, return the smallest range.
                 .sorted(rangeSize)

--- a/src/test/java/software/amazon/smithy/lsp/ext/Harness.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/Harness.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import software.amazon.smithy.lsp.Utils;
 import software.amazon.smithy.lsp.ext.model.SmithyBuildExtensions;
 import software.amazon.smithy.utils.IoUtils;
 
@@ -113,7 +114,12 @@ public class Harness implements AutoCloseable {
     File hs = Files.createTempDir();
     File tmp = Files.createTempDir();
     for (Path path : files) {
-      safeCreateFile(path.getFileName().toString(), IoUtils.readUtf8File(path), hs);
+      if (Utils.isJarFile(path.toString())) {
+        String contents = String.join(System.lineSeparator(), Utils.jarFileContents(path.toString()));
+        safeCreateFile(path.getFileName().toString(), contents, hs);
+      } else {
+        safeCreateFile(path.getFileName().toString(), IoUtils.readUtf8File(path), hs);
+      }
     }
     return loadHarness(ext, hs, tmp);
   }

--- a/src/test/java/software/amazon/smithy/lsp/ext/Harness.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/Harness.java
@@ -16,16 +16,17 @@
 package software.amazon.smithy.lsp.ext;
 
 import com.google.common.io.Files;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import software.amazon.smithy.lsp.ext.model.SmithyBuildExtensions;
+import software.amazon.smithy.utils.IoUtils;
 
 public class Harness implements AutoCloseable {
   private File root;
@@ -95,12 +96,7 @@ public class Harness implements AutoCloseable {
     // TODO: How to make this safe?
     File hs = Files.createTempDir();
     File tmp = Files.createTempDir();
-
-    Either<Exception, SmithyProject> loaded = SmithyProject.load(ext, hs);
-    if (loaded.isRight())
-      return new Harness(hs, tmp, loaded.getRight(), ext);
-    else
-      throw loaded.getLeft();
+    return loadHarness(ext, hs, tmp);
   }
 
   public static Harness create(SmithyBuildExtensions ext, Map<String, String> files) throws Exception {
@@ -110,11 +106,23 @@ public class Harness implements AutoCloseable {
     for (Entry<String, String> entry : files.entrySet()) {
       safeCreateFile(entry.getKey(), entry.getValue(), hs);
     }
+    return loadHarness(ext, hs, tmp);
+  }
+
+  public static Harness create(SmithyBuildExtensions ext, List<Path> files) throws Exception {
+    File hs = Files.createTempDir();
+    File tmp = Files.createTempDir();
+    for (Path path : files) {
+      safeCreateFile(path.getFileName().toString(), IoUtils.readUtf8File(path), hs);
+    }
+    return loadHarness(ext, hs, tmp);
+  }
+
+  private static Harness loadHarness(SmithyBuildExtensions ext, File hs, File tmp) throws Exception {
     Either<Exception, SmithyProject> loaded = SmithyProject.load(ext, hs);
     if (loaded.isRight())
       return new Harness(hs, tmp, loaded.getRight(), ext);
     else
       throw loaded.getLeft();
   }
-
 }

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.lsp.ext;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import com.google.common.collect.ImmutableList;
 import java.io.File;
@@ -31,6 +32,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.junit.Test;
 import software.amazon.smithy.lsp.ext.model.SmithyBuildExtensions;
+import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.utils.ListUtils;
 import software.amazon.smithy.utils.MapUtils;
 
@@ -83,21 +85,67 @@ public class SmithyProjectTest {
         List<Path> modelFiles = ImmutableList.of(modelMain, modelTest);
 
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
-            Map<String, List<Location>> locations = hs.getProject().getLocations();
+            Map<ShapeId, Location> locationMap = hs.getProject().getLocations();
 
-            correctLocation(locations, "SingleLine", 4, 0, 4, 23);
-            correctLocation(locations, "MultiLine", 6, 8,10, 9);
-            correctLocation(locations, "SingleTrait", 13, 0, 13, 18);
-            correctLocation(locations, "MultiTrait", 17, 0,18, 14);
-            correctLocation(locations, "MultiTraitAndLineComments", 32, 0,34, 1);
-            correctLocation(locations,"MultiTraitAndDocComments", 43, 0,45, 1);
-            correctLocation(locations, "OtherStructure", 4, 0, 8, 1);
+            correctLocation(locationMap, "com.foo#SingleLine", 4, 0, 4, 23);
+            correctLocation(locationMap, "com.foo#MultiLine", 6, 8,13, 9);
+            correctLocation(locationMap, "com.foo#SingleTrait", 16, 4, 16, 22);
+            correctLocation(locationMap, "com.foo#MultiTrait", 20, 0,21, 14);
+            correctLocation(locationMap, "com.foo#MultiTraitAndLineComments", 35, 0,37, 1);
+            correctLocation(locationMap,"com.foo#MultiTraitAndDocComments", 46, 0,48, 1);
+            correctLocation(locationMap, "com.example#OtherStructure", 4, 0, 8, 1);
         }
     }
 
-    private void correctLocation(Map<String, List<Location>> locations, String shapeName, int startLine,
+    @Test
+    public void shapeIdFromLocation() throws Exception {
+        Path baseDir = Paths.get(SmithyProjectTest.class.getResource("models").toURI());
+        Path modelMain = baseDir.resolve("main.smithy");
+        Path modelTest = baseDir.resolve("test.smithy");
+        List<Path> modelFiles = ImmutableList.of(modelMain, modelTest);
+
+        try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
+            SmithyProject project = hs.getProject();
+            String uri = "file:" + hs.file("main.smithy");
+            String testUri = "file:" + hs.file("test.smithy");
+
+            assertFalse(project.getShapeIdFromLocation("empty.smithy", new Position(0, 0)).isPresent());
+            assertFalse(project.getShapeIdFromLocation(uri, new Position(0, 0)).isPresent());
+            // Position on shape start line, but before char start
+            assertFalse(project.getShapeIdFromLocation(uri, new Position(17, 0)).isPresent());
+            // Position on shape end line, but after char end
+            assertFalse(project.getShapeIdFromLocation(uri, new Position(14, 10)).isPresent());
+            // Position on shape start line
+            assertEquals(ShapeId.from("com.foo#SingleLine"), project.getShapeIdFromLocation(uri,
+                    new Position(4, 10)).get());
+            // Position on multi-line shape start line
+            assertEquals(ShapeId.from("com.foo#MultiLine"), project.getShapeIdFromLocation(uri,
+                    new Position(6, 8)).get());
+            // Position on multi-line shape end line
+            assertEquals(ShapeId.from("com.foo#MultiLine"), project.getShapeIdFromLocation(uri,
+                    new Position(13, 6)).get());
+            // Member positions
+            assertEquals(ShapeId.from("com.foo#MultiLine$a"), project.getShapeIdFromLocation(uri,
+                    new Position(7,14)).get());
+            assertEquals(ShapeId.from("com.foo#MultiLine$b"), project.getShapeIdFromLocation(uri,
+                    new Position(10,14)).get());
+            assertEquals(ShapeId.from("com.foo#MultiLine$c"), project.getShapeIdFromLocation(uri,
+                    new Position(12,14)).get());
+            // Member positions on target
+            assertEquals(ShapeId.from("com.foo#MultiLine$a"), project.getShapeIdFromLocation(uri,
+                    new Position(7,18)).get());
+            assertEquals(ShapeId.from("com.foo#MultiLine$b"), project.getShapeIdFromLocation(uri,
+                    new Position(10,18)).get());
+            assertEquals(ShapeId.from("com.foo#MultiLine$c"), project.getShapeIdFromLocation(uri,
+                    new Position(12,18)).get());
+            assertEquals(ShapeId.from("com.example#OtherStructure"), project.getShapeIdFromLocation(testUri,
+                    new Position(4, 15)).get());
+        }
+    }
+
+    private void correctLocation(Map<ShapeId, Location> locationMap, String shapeId, int startLine,
                                  int startColumn, int endLine, int endColumn) {
-        Location location = locations.get(shapeName).get(0);
+        Location location = locationMap.get(ShapeId.from(shapeId));
         Range range = new Range(new Position(startLine, startColumn), new Position(endLine, endColumn));
         assertEquals(range, location.getRange());
     }

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
@@ -106,8 +106,8 @@ public class SmithyProjectTest {
 
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
             SmithyProject project = hs.getProject();
-            String uri = "file:" + hs.file("main.smithy");
-            String testUri = "file:" + hs.file("test.smithy");
+            String uri = hs.file("main.smithy").toString();
+            String testUri = hs.file("test.smithy").toString();
 
             assertFalse(project.getShapeIdFromLocation("empty.smithy", new Position(0, 0)).isPresent());
             assertFalse(project.getShapeIdFromLocation(uri, new Position(0, 0)).isPresent());

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
@@ -85,19 +85,20 @@ public class SmithyProjectTest {
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
             Map<String, List<Location>> locations = hs.getProject().getLocations();
 
-            correctLocation(locations, "SingleLine", 4, 5);
-            correctLocation(locations, "MultiLine", 6, 11);
-            correctLocation(locations, "SingleTrait", 13, 14);
-            correctLocation(locations, "MultiTrait", 17, 20);
-            correctLocation(locations, "MultiTraitAndLineComments", 33, 36);
-            correctLocation(locations,"MultiTraitAndDocComments", 41, 44);
-            correctLocation(locations, "OtherStructure", 4, 9);
+            correctLocation(locations, "SingleLine", 4, 0, 4, 23);
+            correctLocation(locations, "MultiLine", 6, 8,10, 9);
+            correctLocation(locations, "SingleTrait", 13, 0, 13, 18);
+            correctLocation(locations, "MultiTrait", 17, 0,18, 14);
+            correctLocation(locations, "MultiTraitAndLineComments", 32, 0,34, 1);
+            correctLocation(locations,"MultiTraitAndDocComments", 43, 0,45, 1);
+            correctLocation(locations, "OtherStructure", 4, 0, 8, 1);
         }
     }
 
-    private void correctLocation(Map<String, List<Location>> locations, String shapeName, int start, int end) {
+    private void correctLocation(Map<String, List<Location>> locations, String shapeName, int startLine,
+                                 int startColumn, int endLine, int endColumn) {
         Location location = locations.get(shapeName).get(0);
-        Range range = new Range(new Position(start, 0), new Position(end, 0));
+        Range range = new Range(new Position(startLine, startColumn), new Position(endLine, endColumn));
         assertEquals(range, location.getRange());
     }
 }

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
@@ -16,8 +16,12 @@
 package software.amazon.smithy.lsp.ext;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -26,12 +30,15 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
@@ -158,6 +165,73 @@ public class SmithyTextDocumentServiceTest {
 
     }
 
+    @Test
+    public void definitions() throws Exception {
+        Path baseDir = Paths.get(SmithyProjectTest.class.getResource("models").toURI());
+        String modelFilename = "main.smithy";
+        Path modelMain = baseDir.resolve(modelFilename);
+        List<Path> modelFiles = ImmutableList.of(modelMain);
+
+        try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
+            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty(), hs.getTempFolder());
+            StubClient client = new StubClient();
+            tds.createProject(hs.getConfig(), hs.getRoot());
+            tds.setClient(client);
+            TextDocumentIdentifier mainTdi = new TextDocumentIdentifier("file:" + hs.file(modelFilename));
+
+            // Resolves via token => shape name.
+            DefinitionParams commentParams = definitionParams(mainTdi, 43, 37);
+            Location commentLocation = tds.definition(commentParams).get().getLeft().get(0);
+
+            // Resolves via shape target location in model.
+            DefinitionParams memberParams = definitionParams(mainTdi, 12, 18);
+            Location memberTargetLocation = tds.definition(memberParams).get().getLeft().get(0);
+
+            // Resolves via member shape target location in prelude.
+            DefinitionParams preludeTargetParams = definitionParams(mainTdi, 36, 12);
+            Location preludeTargetLocation = tds.definition(preludeTargetParams).get().getLeft().get(0);
+
+            // Resolves to current location.
+            DefinitionParams selfParams = definitionParams(mainTdi, 36, 0);
+            Location selfLocation = tds.definition(selfParams).get().getLeft().get(0);
+
+            // Resolves via operation input.
+            DefinitionParams inputParams = definitionParams(mainTdi, 52, 16);
+            Location inputLocation = tds.definition(inputParams).get().getLeft().get(0);
+
+            // Resolves via operation output.
+            DefinitionParams outputParams = definitionParams(mainTdi, 53, 17);
+            Location outputLocation = tds.definition(outputParams).get().getLeft().get(0);
+
+            // Resolves via operation error.
+            DefinitionParams errorParams = definitionParams(mainTdi, 54, 14);
+            Location errorLocation = tds.definition(errorParams).get().getLeft().get(0);
+
+            // Resolves via resource ids.
+            DefinitionParams idParams = definitionParams(mainTdi, 75, 29);
+            Location idLocation = tds.definition(idParams).get().getLeft().get(0);
+
+            // Resolves via resource read.
+            DefinitionParams readParams = definitionParams(mainTdi, 76, 12);
+            Location readLocation = tds.definition(readParams).get().getLeft().get(0);
+
+            // Does not correspond to shape.
+            DefinitionParams noMatchParams = definitionParams(mainTdi, 0, 0);
+            List<Location> noMatchLocationList = (List<Location>) tds.definition(noMatchParams).get().getLeft();
+
+            correctLocation(commentLocation, modelFilename, 20, 0, 21, 14);
+            correctLocation(memberTargetLocation, modelFilename, 4, 0, 4, 23);
+            correctLocation(selfLocation, modelFilename, 35, 0, 37, 1);
+            correctLocation(inputLocation, modelFilename, 57, 0, 61, 1);
+            correctLocation(outputLocation, modelFilename, 63, 0, 66, 1);
+            correctLocation(errorLocation, modelFilename, 69, 0, 72, 1);
+            correctLocation(idLocation, modelFilename, 79, 0, 79, 11);
+            correctLocation(readLocation, modelFilename, 51, 0, 55, 1);
+            assertTrue(preludeTargetLocation.getUri().endsWith("prelude.smithy"));
+            assertTrue(noMatchLocationList.isEmpty());
+        }
+    }
+
     private class StubClient implements LanguageClient {
         public List<PublishDiagnosticsParams> diagnostics = new ArrayList<>();
         public List<MessageParams> shown = new ArrayList<>();
@@ -219,5 +293,17 @@ public class SmithyTextDocumentServiceTest {
 
     private String uri(File f) {
         return f.toURI().toString();
+    }
+
+    private DefinitionParams definitionParams(TextDocumentIdentifier tdi, int line, int character) {
+        return new DefinitionParams(tdi, new Position(line, character));
+    }
+
+    private void correctLocation(Location location, String uri, int startLine, int startCol, int endLine, int endCol) {
+        assertEquals(startLine, location.getRange().getStart().getLine());
+        assertEquals(startCol, location.getRange().getStart().getCharacter());
+        assertEquals(endLine, location.getRange().getEnd().getLine());
+        assertEquals(endCol, location.getRange().getEnd().getCharacter());
+        assertTrue(location.getUri().endsWith(uri));
     }
 }

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
@@ -177,7 +177,7 @@ public class SmithyTextDocumentServiceTest {
             StubClient client = new StubClient();
             tds.createProject(hs.getConfig(), hs.getRoot());
             tds.setClient(client);
-            TextDocumentIdentifier mainTdi = new TextDocumentIdentifier("file:" + hs.file(modelFilename));
+            TextDocumentIdentifier mainTdi = new TextDocumentIdentifier(hs.file(modelFilename).toString());
 
             // Resolves via token => shape name.
             DefinitionParams commentParams = definitionParams(mainTdi, 43, 37);

--- a/src/test/resources/software/amazon/smithy/lsp/ext/models/main.smithy
+++ b/src/test/resources/software/amazon/smithy/lsp/ext/models/main.smithy
@@ -4,26 +4,25 @@ namespace example.foo
 
 structure SingleLine {}
 
-structure MultiLine {
-    a: String,
-    b: String,
-    c: String
-}
+        structure MultiLine {
+            a: String,
+            b: String,
+            c: String
+        }
 
-@pattern("^[A-Za-z0-9 ]+$")
+    @pattern("^[A-Za-z0-9 ]+$")
 string SingleTrait
 
 @input
 @error("client")
 structure MultiTrait {
-    a: String
-}
+    a: String}
 
 // Line comments
 // comments
 @input
-// comments
-@error("client")
+    // comments
+    @error("client")
 @references(
     [
         {
@@ -34,6 +33,9 @@ structure MultiTrait {
 structure MultiTraitAndLineComments {
     a: String
 }
+
+
+
 
 /// Doc comments
 /// comments

--- a/src/test/resources/software/amazon/smithy/lsp/ext/models/main.smithy
+++ b/src/test/resources/software/amazon/smithy/lsp/ext/models/main.smithy
@@ -1,0 +1,44 @@
+$version: "1.0"
+
+namespace example.foo
+
+structure SingleLine {}
+
+structure MultiLine {
+    a: String,
+    b: String,
+    c: String
+}
+
+@pattern("^[A-Za-z0-9 ]+$")
+string SingleTrait
+
+@input
+@error("client")
+structure MultiTrait {
+    a: String
+}
+
+// Line comments
+// comments
+@input
+// comments
+@error("client")
+@references(
+    [
+        {
+            resource: City
+        }
+    ]
+)
+structure MultiTraitAndLineComments {
+    a: String
+}
+
+/// Doc comments
+/// comments
+@input
+@error("client")
+structure MultiTraitAndDocComments {
+    a: String
+}

--- a/src/test/resources/software/amazon/smithy/lsp/ext/models/main.smithy
+++ b/src/test/resources/software/amazon/smithy/lsp/ext/models/main.smithy
@@ -1,20 +1,23 @@
 $version: "1.0"
 
-namespace example.foo
+namespace com.foo
 
 structure SingleLine {}
 
         structure MultiLine {
             a: String,
+
+
             b: String,
-            c: String
+            @required
+            c: SingleLine
         }
 
     @pattern("^[A-Za-z0-9 ]+$")
-string SingleTrait
+    string SingleTrait
 
 @input
-@error("client")
+@tags(["foo"])
 structure MultiTrait {
     a: String}
 
@@ -22,12 +25,12 @@ structure MultiTrait {
 // comments
 @input
     // comments
-    @error("client")
-@references(
-    [
-        {
-            resource: City
-        }
+    @tags(["a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f"
     ]
 )
 structure MultiTraitAndLineComments {
@@ -38,9 +41,40 @@ structure MultiTraitAndLineComments {
 
 
 /// Doc comments
-/// comments
+/// Comment about corresponding MultiTrait shape
 @input
-@error("client")
+@tags(["foo"])
 structure MultiTraitAndDocComments {
     a: String
 }
+
+@readonly
+operation MyOperation {
+    input: MyInput,
+    output: MyOutput,
+    errors: [MyError]
+}
+
+structure MyInput {
+    foo: String,
+    @required
+    myId: MyId
+}
+
+structure MyOutput {
+    corge: String,
+    qux: String
+}
+
+@error("client")
+structure MyError {
+    blah: String,
+    blahhhh: Integer
+}
+
+resource MyResource {
+    identifiers: { myId: MyId },
+    read: MyOperation
+}
+
+string MyId

--- a/src/test/resources/software/amazon/smithy/lsp/ext/models/test.smithy
+++ b/src/test/resources/software/amazon/smithy/lsp/ext/models/test.smithy
@@ -7,3 +7,6 @@ structure OtherStructure {
     bar: String,
     baz: Integer
 }
+
+
+

--- a/src/test/resources/software/amazon/smithy/lsp/ext/models/test.smithy
+++ b/src/test/resources/software/amazon/smithy/lsp/ext/models/test.smithy
@@ -1,0 +1,9 @@
+$version: "1.0"
+
+namespace com.example
+
+structure OtherStructure {
+    foo: String,
+    bar: String,
+    baz: Integer
+}


### PR DESCRIPTION
Currently, the source location of a shape is used to set both the start and end positions of a location range when building the map of definition locations used by the definition provider.

This CR improves the definition locations by finding the appropriate end position of a shape. By working from the bottom of a file to the top, the real end of a shape definition can be found by ignoring the traits and comments of the shape beneath it in a file.

This also adds a `getShapeIdFromLocation` method which returns the shapeId of the shape defined at the given location within the model.

With improved definition locations, clients can render more accurate definitions.

In VS Code, the Peek Definition pane currently shows the following definition for a shape:
![current](https://user-images.githubusercontent.com/782571/163630542-6c22fb14-51be-4b84-8666-1673f38f99c7.png)

With the improved definition location, the entire shape is highlighted:
![updated](https://user-images.githubusercontent.com/782571/163630538-5cc12f9f-403d-452e-815d-76598914a00b.png)

When using the "Go to Definition" context option, the cursor still moves to the beginning of the shape. With this CR, when selecting "Go to Definition" when the cursor is already within a shape, the cursor will no longer move. Currently, the cursor moves to the beginning of the shape definition due to the definition location being a zero-length location range that precedes the actual shape definition.

This CR also cleans up the unused `reload` method in SmithyProject.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
