### PR TITLE
Add selector protocol extension

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SelectorParams.java
+++ b/src/main/java/software/amazon/smithy/lsp/SelectorParams.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.lsp;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+
+public class SelectorParams {
+    @NonNull
+    private String expression;
+
+    public SelectorParams(@NonNull final String selector) {
+        this.expression = Preconditions.checkNotNull(selector, "selector");
+    }
+
+    public String getExpression() {
+        return this.expression;
+    }
+}

--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -20,6 +20,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -27,12 +28,14 @@ import java.util.stream.Collectors;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.WorkspaceFolder;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.LanguageServer;
@@ -142,6 +145,20 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
       future.completeExceptionally(e);
       return future;
     }
+  }
+
+  @Override
+  public CompletableFuture<List<? extends Location>> selectorCommand(SelectorParams selectorParams) {
+    LspLog.println("Received selector Command: " + selectorParams.getExpression());
+    if (this.tds.isPresent()) {
+      Either<Exception, List<Location>> result = this.tds.get().runSelector(selectorParams.getExpression());
+      if (result.isRight()) {
+        return CompletableFuture.completedFuture(result.getRight());
+      } else {
+        LspLog.println("Resolve model validation errors and re-run selector command: " + result.getLeft());
+      }
+    }
+    return CompletableFuture.completedFuture(Collections.emptyList());
   }
 
 }

--- a/src/main/java/software/amazon/smithy/lsp/SmithyProtocolExtensions.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyProtocolExtensions.java
@@ -15,7 +15,9 @@
 
 package software.amazon.smithy.lsp;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
@@ -29,4 +31,6 @@ public interface SmithyProtocolExtensions {
   @JsonRequest
   CompletableFuture<String> jarFileContents(TextDocumentIdentifier documentUri);
 
+  @JsonRequest
+  CompletableFuture<List<? extends Location>> selectorCommand(SelectorParams selectorParams);
 }

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -522,6 +522,15 @@ public class SmithyTextDocumentService implements TextDocumentService {
 
     }
 
+    /**
+     * Run a selector expression against the loaded model in the workspace.
+     * @param expression the selector expression
+     * @return list of locations of shapes that match expression
+     */
+    public Either<Exception, List<Location>> runSelector(String expression) {
+        return this.project.runSelector(expression);
+    }
+
     private void sendInfo(String msg) {
         this.client.ifPresent(client -> {
             client.showMessage(new MessageParams(MessageType.Info, msg));

--- a/src/test/java/software/amazon/smithy/lsp/ext/Harness.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/Harness.java
@@ -69,17 +69,6 @@ public class Harness implements AutoCloseable {
     return f;
   }
 
-  public File addFile(String path, String contents) throws Exception {
-    File f = safeCreateFile(path, contents, this.root);
-    Either<Exception, SmithyProject> loaded = this.project.recompile(f, null);
-    if (loaded.isRight())
-      this.project = loaded.getRight();
-    else
-      throw loaded.getLeft();
-
-    return f;
-  }
-
   public File file(String path) throws Exception {
     return Paths.get(root.getAbsolutePath(), path).toFile();
   }

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
@@ -54,7 +54,6 @@ public class SmithyProjectTest {
 
             assertEquals(ListUtils.of(inBla, inFoo), smithyFiles);
         }
-
     }
 
     @Test
@@ -74,7 +73,6 @@ public class SmithyProjectTest {
 
             assertEquals(expectedFiles, smithyFiles);
         }
-
     }
 
     @Test

--- a/src/test/resources/software/amazon/smithy/lsp/ext/models/broken.smithy
+++ b/src/test/resources/software/amazon/smithy/lsp/ext/models/broken.smithy
@@ -1,0 +1,7 @@
+$version: "1.0"
+
+namespace foo.com
+
+structure MyStruct {
+    a: AnotherStruct
+}


### PR DESCRIPTION
This PR adds a `selectorCommand` protocol extension. This endpoint allows a language client to send a request that contains a selector expression. The expression is run against the loaded model and a list of locations for any shapes that match the selector is returned. If no shapes match the selector, an empty list of locations will be returned. If the model has validation errors and the selector cannot be run against it, an empty list is returned and a log is emitted to .smithy.lsp.log.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
