### PR TITLE
Log selector command results

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -153,7 +153,9 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
     if (this.tds.isPresent()) {
       Either<Exception, List<Location>> result = this.tds.get().runSelector(selectorParams.getExpression());
       if (result.isRight()) {
-        return CompletableFuture.completedFuture(result.getRight());
+        List<Location> locations = result.getRight();
+        LspLog.println(String.format("Selector command found %s matching shapes.", locations.size()));
+        return CompletableFuture.completedFuture(locations);
       } else {
         LspLog.println("Resolve model validation errors and re-run selector command: " + result.getLeft());
       }


### PR DESCRIPTION
Log number of matching locations that result from successfully running the selector expression.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
