### PR TITLE
Fix definition of trait on member

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -283,6 +283,15 @@ public class SmithyTextDocumentService implements TextDocumentService {
                         .map(Shape::getId)
                         .filter(shape -> shape.getName().equals(found))
                         .findFirst();
+                // If none of the neighbors match the token, check traits applied to members of the shape.
+                if (!target.isPresent()) {
+                    target = shapeWalker.walkShapes(initialShape).stream()
+                            .filter(shape -> shape.isMemberShape())
+                            .flatMap(shape -> shape.getAllTraits().values().stream())
+                            .map(trait -> trait.toShapeId())
+                            .filter(shapeId -> shapeId.getName().equals(found))
+                            .findFirst();
+                }
                 // Use location on target, or else default to initial shape.
                 locations = Collections.singletonList(project.getLocations().get(target.orElse(initialShapeId.get())));
             } else {

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionParams;
@@ -276,22 +277,19 @@ public class SmithyTextDocumentService implements TextDocumentService {
             if (initialShapeId.isPresent()) {
                 Model model = project.getModel().unwrap();
                 Shape initialShape = model.getShape(initialShapeId.get()).get();
-                // Find first neighbor (non-member) with name that matches token.
+                // Find the first non-member neighbor shape or trait applied to a member whose name matches the token.
                 Walker shapeWalker = new Walker(NeighborProviderIndex.of(model).getProvider());
                 Optional<ShapeId> target = shapeWalker.walkShapes(initialShape).stream()
-                        .filter(shape -> !shape.isMemberShape())
-                        .map(Shape::getId)
-                        .filter(shape -> shape.getName().equals(found))
+                        .flatMap(shape -> {
+                            if (shape.isMemberShape()) {
+                                return shape.getAllTraits().values().stream()
+                                        .map(trait -> trait.toShapeId());
+                            } else {
+                                return Stream.of(shape.getId());
+                            }
+                        })
+                        .filter(shapeId -> shapeId.getName().equals(found))
                         .findFirst();
-                // If none of the neighbors match the token, check traits applied to members of the shape.
-                if (!target.isPresent()) {
-                    target = shapeWalker.walkShapes(initialShape).stream()
-                            .filter(shape -> shape.isMemberShape())
-                            .flatMap(shape -> shape.getAllTraits().values().stream())
-                            .map(trait -> trait.toShapeId())
-                            .filter(shapeId -> shapeId.getName().equals(found))
-                            .findFirst();
-                }
                 // Use location on target, or else default to initial shape.
                 locations = Collections.singletonList(project.getLocations().get(target.orElse(initialShapeId.get())));
             } else {

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
@@ -194,6 +194,14 @@ public class SmithyTextDocumentServiceTest {
             DefinitionParams preludeTargetParams = definitionParams(mainTdi, 36, 12);
             Location preludeTargetLocation = tds.definition(preludeTargetParams).get().getLeft().get(0);
 
+            // Resolves via top-level trait location in prelude.
+            DefinitionParams preludeTraitParams = definitionParams(mainTdi, 25, 3);
+            Location preludeTraitLocation = tds.definition(preludeTraitParams).get().getLeft().get(0);
+
+            // Resolves via member-applied trait location in prelude.
+            DefinitionParams preludeMemberTraitParams = definitionParams(mainTdi, 59, 10);
+            Location preludeMemberTraitLocation = tds.definition(preludeMemberTraitParams).get().getLeft().get(0);
+
             // Resolves to current location.
             DefinitionParams selfParams = definitionParams(mainTdi, 36, 0);
             Location selfLocation = tds.definition(selfParams).get().getLeft().get(0);
@@ -231,6 +239,8 @@ public class SmithyTextDocumentServiceTest {
             correctLocation(idLocation, modelFilename, 79, 0, 79, 11);
             correctLocation(readLocation, modelFilename, 51, 0, 55, 1);
             assertTrue(preludeTargetLocation.getUri().endsWith("prelude.smithy"));
+            assertTrue(preludeTraitLocation.getUri().endsWith("prelude.smithy"));
+            assertTrue(preludeMemberTraitLocation.getUri().endsWith("prelude.smithy"));
             assertTrue(noMatchLocationList.isEmpty());
         }
     }


### PR DESCRIPTION
This PR fixes #42.

This fixes returning the correct definition location for a trait applied to a member. It also adds a test for the definition location of a trait at the top level.

Previously, only the non-member shapes were walked to find the target of a specific location within a model. This adds logic to also check the traits applied to members within the shape.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
