### PR TITLE
Fix use block parsing in preamble

### DIFF
--- a/src/test/java/software/amazon/smithy/lsp/ext/DocumentTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/DocumentTest.java
@@ -59,6 +59,8 @@ public class DocumentTest {
         DocumentPreamble preamble = Document.detectPreamble(lines);
 
         assertEquals("ns.preamble", preamble.getCurrentNamespace().get());
+        assertEquals(new Position(2, 0), preamble.getUseBlockRange().getStart());
+        assertEquals(new Position(2, 14), preamble.getUseBlockRange().getEnd());
         assertFalse(preamble.isBlankSeparated());
     }
 

--- a/src/test/java/software/amazon/smithy/lsp/ext/DocumentTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/DocumentTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.lsp.ext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.eclipse.lsp4j.Position;
+import org.junit.Test;
+
+public class DocumentTest {
+
+    @Test
+    public void detectPreamble() throws Exception {
+        Path baseDir = Paths.get(Document.class.getResource("models").toURI());
+        Path preambleModel = baseDir.resolve("preamble.smithy");
+        List<String> lines = Files.readAllLines(preambleModel);
+        DocumentPreamble preamble = Document.detectPreamble(lines);
+
+        assertEquals("ns.preamble", preamble.getCurrentNamespace().get());
+        assertEquals(new Position(2, 0), preamble.getNamespaceRange().getStart());
+        assertEquals(new Position(2, 21), preamble.getNamespaceRange().getEnd());
+        assertEquals(new Position(4, 0), preamble.getUseBlockRange().getStart());
+        assertEquals(new Position(6, 19), preamble.getUseBlockRange().getEnd());
+        assertTrue(preamble.hasImport("ns.foo#FooTrait"));
+        assertTrue(preamble.hasImport("ns.bar#BarTrait"));
+        assertFalse(preamble.hasImport("ns.baz#Baz"));
+        assertTrue(preamble.isBlankSeparated());
+    }
+
+    @Test
+    public void detectPreambleNonBlankSeparated() {
+        List<String> lines = ImmutableList.of(
+                "$version: \"1.0\"",
+                "namespace ns.preamble",
+                "use ns.foo#Foo",
+                "@Foo",
+                "string MyString"
+        );
+        DocumentPreamble preamble = Document.detectPreamble(lines);
+
+        assertEquals("ns.preamble", preamble.getCurrentNamespace().get());
+        assertFalse(preamble.isBlankSeparated());
+    }
+
+    @Test
+    public void detectPreambleWithoutUseStatements() {
+        List<String> lines = ImmutableList.of(
+                "$version: \"1.0\"",
+                "namespace ns.preamble",
+                "string MyString"
+        );
+        DocumentPreamble preamble = Document.detectPreamble(lines);
+
+        assertEquals("ns.preamble", preamble.getCurrentNamespace().get());
+        assertFalse(preamble.isBlankSeparated());
+    }
+}

--- a/src/test/resources/software/amazon/smithy/lsp/ext/models/preamble.smithy
+++ b/src/test/resources/software/amazon/smithy/lsp/ext/models/preamble.smithy
@@ -1,0 +1,11 @@
+$version: "1.0"
+
+namespace ns.preamble
+
+use ns.foo#FooTrait
+
+use ns.bar#BarTrait
+
+@FooTrait
+@BarTrait
+string MyString


### PR DESCRIPTION
This PR fixes the parsing of use statements in the preamble of a model file.

Currently, if any blank lines appear with in the use statement block, parsing of the preamble will only detect the use statements that precede the first blank line.

This issue results in duplicate use statements being added when a trait completion is used.

Take this example model:
```
$version: "1.0"

namespace ns.preamble

use ns.foo#FooTrait

use ns.bar#BarTrait

@FooTrait
string MyString 
```

If `@Bar` was typed to target `MyString`, with the client opting to use the `@BarTrait` completion, it would result in a duplicate `use` statement being added:
```
$version: "1.0"

namespace ns.preamble

use ns.foo#FooTrait
use ns.foo#BarTrait

use ns.bar#BarTrait

@FooTrait
string MyString 
```

This fix corrects the parsing so that the `ns.bar#BarTrait` use statement is correctly identified as already in the model file and prevents it from being added a second time.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
