### PR TITLE
Update lsp4j to 0.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ publishing {
 
 
 dependencies {
-    implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.9.0"
+    implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.14.0"
     implementation "software.amazon.smithy:smithy-model:[1.0, 2.0["
     implementation 'io.get-coursier:interface:1.0.4'
 


### PR DESCRIPTION
This PR updates LSP4J to the latest version, 0.14.0.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
