### PR TITLE
Fix javadoc warnings and suppress from lsp4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,10 @@ dependencies {
     testImplementation "junit:junit:4.13"
 }
 
+tasks.withType(Javadoc).all {
+    options.addStringOption('Xdoclint:none', '-quiet')
+}
+
 tasks.withType(Test) {
     testLogging {
         events TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED, TestLogEvent.STANDARD_OUT, TestLogEvent.STANDARD_ERROR

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -91,6 +91,7 @@ public class SmithyTextDocumentService implements TextDocumentService {
 
     /**
      * @param client Language Client to be used by text document service.
+     * @param tempFile Temporary File to be used by text document service.
      */
     public SmithyTextDocumentService(Optional<LanguageClient> client, File tempFile) {
         this.client = client;

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -75,8 +75,9 @@ public final class SmithyProject {
      * This version of the method above is used when the
      * file is in ephemeral storage (temporary location when file is being changed)
      *
-     * @param changed file which may or may not be already tracked by this project
-     * @return either an error, or a loaded project
+     * @param changed file which may or may not be already tracked by this project.
+     * @param exclude file to exclude from being recompiled.
+     * @return either an error, or a loaded project.
      */
     public Either<Exception, SmithyProject> recompile(File changed, File exclude) {
         List<File> newFiles = new ArrayList<>();
@@ -119,9 +120,9 @@ public final class SmithyProject {
      * Load the project using a SmithyBuildExtensions configuration and workspace
      * root.
      *
-     * @param config configuration
-     * @param root   workspace root
-     * @return either an error or a loaded project
+     * @param config configuration.
+     * @param root workspace root.
+     * @return either an error or a loaded project.
      */
     public static Either<Exception, SmithyProject> load(SmithyBuildExtensions config, File root) {
         List<Path> imports = config.getImports().stream().map(p -> Paths.get(root.getAbsolutePath(), p).normalize())
@@ -145,8 +146,8 @@ public final class SmithyProject {
 
     /**
      * Run a selector expression against the loaded model in the workspace.
-     * @param expression the selector expression
-     * @return list of locations of shapes that match expression
+     * @param expression the selector expression.
+     * @return list of locations of shapes that match expression.
      */
     public Either<Exception, List<Location>> runSelector(String expression) {
         try {
@@ -273,8 +274,8 @@ public final class SmithyProject {
     /**
      * Returns the shapeId of the shape that corresponds to the file uri and position within the model.
      *
-     * @param uri String uri of model file
-     * @param position Cursor position within model file
+     * @param uri String uri of model file.
+     * @param position Cursor position within model file.
      * @return ShapeId of corresponding shape defined at location.
      */
     public Optional<ShapeId> getShapeIdFromLocation(String uri, Position position) {


### PR DESCRIPTION
Publishing of Javadoc was enabled in https://github.com/awslabs/smithy-language-server/pull/47.

This PR fixes a few missing Javadoc params and improves the formatting. It also disables Javadoc warnings. This is necessary due to LSP4J's Javadoc issues that pollute the build output.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
