### PR TITLE
Show version number in connect message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,19 @@ tasks.withType(Test) {
     }
 }
 
+task createProperties(dependsOn: processResources) {
+    doLast {
+        new File("$buildDir/resources/main/version.properties").withWriter { w ->
+            Properties p = new Properties()
+            p['version'] = project.version.toString()
+            p.store w, null
+        }
+    }
+}
+
+classes {
+    dependsOn createProperties
+}
 
 application {
     // Define the main class for the application.

--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.eclipse.lsp4j.CompletionOptions;
@@ -126,8 +127,16 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
 
   @Override
   public void connect(LanguageClient client) {
+    Properties props = new Properties();
+    String message = "Hello from smithy-language-server!";
+    try {
+      props.load(SmithyLanguageServer.class.getClassLoader().getResourceAsStream("version.properties"));
+      message = "Hello from smithy-language-server " + props.getProperty("version") + "!";
+    } catch (Exception e) {
+      LspLog.println("Could not read Language Server version: " + e);
+    }
     tds.ifPresent(tds -> tds.setClient(client));
-    client.showMessage(new MessageParams(MessageType.Info, "Hello from smithy-language-server !"));
+    client.showMessage(new MessageParams(MessageType.Info, message));
   }
 
   @Override

--- a/src/main/resources/.gitkeep
+++ b/src/main/resources/.gitkeep
@@ -1,0 +1,1 @@
+Delete this file as soon as actual an actual resources is added to this directory.


### PR DESCRIPTION
This updates the `connect` method to include the version number in the message when a Language Client connects to the server.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
