### PR TITLE
Create temp dir for standalone model file

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.lsp;
 
+import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -64,7 +65,6 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
 
   @Override
   public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
-    LspLog.println(params.getWorkspaceFolders());
     if (params.getRootUri() != null) {
       try {
         workspaceRoot = new File(new URI(params.getRootUri()));
@@ -75,6 +75,18 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
       }
     } else {
       LspLog.println("Workspace root was null");
+    }
+
+    if (params.getWorkspaceFolders() == null) {
+      try {
+        File temp = Files.createTempDirectory("tmp-smithy-language-server-workspace").toFile();
+        System.out.println("Created temporary workspace root: " + temp);
+        temp.deleteOnExit();
+        WorkspaceFolder workspaceFolder = new WorkspaceFolder(temp.toURI().toString());
+        params.setWorkspaceFolders(ImmutableList.of(workspaceFolder));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
     }
 
     // TODO: This will break on multi-root workspaces
@@ -102,7 +114,6 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
   @Override
   public void exit() {
     System.exit(0);
-
   }
 
   @Override

--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.lsp;
 
-import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -45,13 +44,12 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 import software.amazon.smithy.lsp.ext.LspLog;
 import software.amazon.smithy.lsp.ext.ValidationException;
+import software.amazon.smithy.utils.ListUtils;
 
 public class SmithyLanguageServer implements LanguageServer, LanguageClientAware, SmithyProtocolExtensions {
-
+  File tempWorkspaceRoot;
   private final Optional<LanguageClient> client = Optional.empty();
-
   private File workspaceRoot;
-
   private Optional<SmithyTextDocumentService> tds = Optional.empty();
 
   @Override
@@ -79,11 +77,11 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
 
     if (params.getWorkspaceFolders() == null) {
       try {
-        File temp = Files.createTempDirectory("tmp-smithy-language-server-workspace").toFile();
-        System.out.println("Created temporary workspace root: " + temp);
-        temp.deleteOnExit();
-        WorkspaceFolder workspaceFolder = new WorkspaceFolder(temp.toURI().toString());
-        params.setWorkspaceFolders(ImmutableList.of(workspaceFolder));
+        tempWorkspaceRoot = Files.createTempDirectory("smithy-lsp-workspace").toFile();
+        System.out.println("Created temporary workspace root: " + tempWorkspaceRoot);
+        tempWorkspaceRoot.deleteOnExit();
+        WorkspaceFolder workspaceFolder = new WorkspaceFolder(tempWorkspaceRoot.toURI().toString());
+        params.setWorkspaceFolders(ListUtils.of(workspaceFolder));
       } catch (IOException e) {
         e.printStackTrace();
       }

--- a/src/test/java/software/amazon/smithy/lsp/SmithyLanguageServerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/SmithyLanguageServerTest.java
@@ -1,0 +1,54 @@
+package software.amazon.smithy.lsp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import org.eclipse.lsp4j.CompletionOptions;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.lsp4j.WorkspaceFolder;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import software.amazon.smithy.utils.ListUtils;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class SmithyLanguageServerTest {
+    @Test
+    public void initializeServer() throws Exception {
+        InitializeParams initParams = new InitializeParams();
+        File temp = Files.createTempDirectory("smithy-lsp-test").toFile();
+        temp.deleteOnExit();
+        initParams.setWorkspaceFolders(ListUtils.of(new WorkspaceFolder(temp.toURI().toString())));
+        SmithyLanguageServer languageServer = new SmithyLanguageServer();
+        InitializeResult initResults = languageServer.initialize(initParams).get();
+        ServerCapabilities capabilities = initResults.getCapabilities();
+
+        assertNull(languageServer.tempWorkspaceRoot);
+        assertEquals(TextDocumentSyncKind.Full, capabilities.getTextDocumentSync().getLeft());
+        assertFalse(capabilities.getCodeActionProvider().getLeft());
+        assertTrue(capabilities.getDefinitionProvider().getLeft());
+        assertTrue(capabilities.getDeclarationProvider().getLeft());
+        assertEquals(new CompletionOptions(true, null), capabilities.getCompletionProvider());
+        assertFalse(capabilities.getHoverProvider().getLeft());
+    }
+
+    @Test
+    public void initializeWithTemporaryWorkspace() throws Exception {
+        InitializeParams initParams = new InitializeParams();
+        SmithyLanguageServer languageServer = new SmithyLanguageServer();
+        languageServer.initialize(initParams);
+
+        assertNotNull(languageServer.tempWorkspaceRoot);
+        assertTrue(languageServer.tempWorkspaceRoot.exists());
+        assertTrue(languageServer.tempWorkspaceRoot.isDirectory());
+        assertTrue(languageServer.tempWorkspaceRoot.canWrite());
+    }
+}


### PR DESCRIPTION
This PR updates the how the language server is initialized to handle editing a standalone smithy model file. When a client is editing a single model file, a workspace may not have been created yet. This PR checks if the workspace is present in the server initialization params and creates a temporary directory to use in its absence.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
