### PR TITLE
Switch to ListUtils.of

### DIFF
--- a/src/test/java/software/amazon/smithy/lsp/ext/DocumentTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/DocumentTest.java
@@ -19,13 +19,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import org.eclipse.lsp4j.Position;
 import org.junit.Test;
+import software.amazon.smithy.utils.ListUtils;
 
 public class DocumentTest {
 
@@ -49,7 +49,7 @@ public class DocumentTest {
 
     @Test
     public void detectPreambleNonBlankSeparated() {
-        List<String> lines = ImmutableList.of(
+        List<String> lines = ListUtils.of(
                 "$version: \"1.0\"",
                 "namespace ns.preamble",
                 "use ns.foo#Foo",
@@ -66,7 +66,7 @@ public class DocumentTest {
 
     @Test
     public void detectPreambleWithoutUseStatements() {
-        List<String> lines = ImmutableList.of(
+        List<String> lines = ListUtils.of(
                 "$version: \"1.0\"",
                 "namespace ns.preamble",
                 "string MyString"

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyBuildExtensionsTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyBuildExtensionsTest.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.lsp.ext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -26,6 +25,7 @@ import java.util.stream.Collectors;
 import org.junit.Test;
 import software.amazon.smithy.lsp.ext.model.MavenRepository;
 import software.amazon.smithy.lsp.ext.model.SmithyBuildExtensions;
+import software.amazon.smithy.utils.ListUtils;
 
 public class SmithyBuildExtensionsTest {
 
@@ -37,8 +37,8 @@ public class SmithyBuildExtensionsTest {
                 "[{\"url\": \"r1\"}, {\"url\": \"r2\"}]}}";
         SmithyBuildExtensions loadedMavenConfig = SmithyBuildLoader.load(DUMMY_PATH, mavenConfig);
 
-        assertEquals(ImmutableList.of("d1", "d2"), loadedMavenConfig.getMavenConfig().getDependencies());
-        assertEquals(ImmutableList.of("r1", "r2"), loadedMavenConfig.getMavenConfig().getRepositories()
+        assertEquals(ListUtils.of("d1", "d2"), loadedMavenConfig.getMavenConfig().getDependencies());
+        assertEquals(ListUtils.of("r1", "r2"), loadedMavenConfig.getMavenConfig().getRepositories()
                 .stream().map(MavenRepository::getUrl).collect(Collectors.toList()));
     }
 
@@ -47,8 +47,8 @@ public class SmithyBuildExtensionsTest {
         String json = "{\"mavenRepositories\": [\"bla\", \"ta\"], \"mavenDependencies\": [\"a1\", \"a2\"]}";
         SmithyBuildExtensions loaded = SmithyBuildLoader.load(DUMMY_PATH, json);
 
-        assertEquals(ImmutableList.of("a1", "a2"), loaded.getMavenConfig().getDependencies());
-        assertEquals(ImmutableList.of("bla", "ta"), loaded.getMavenConfig().getRepositories()
+        assertEquals(ListUtils.of("a1", "a2"), loaded.getMavenConfig().getDependencies());
+        assertEquals(ListUtils.of("bla", "ta"), loaded.getMavenConfig().getRepositories()
                 .stream().map(MavenRepository::getUrl).collect(Collectors.toList()));
     }
 
@@ -57,26 +57,26 @@ public class SmithyBuildExtensionsTest {
         String noExtensions = "{}";
         SmithyBuildExtensions loadedNoExtensions = SmithyBuildLoader.load(DUMMY_PATH, noExtensions);
         assertNotNull(loadedNoExtensions.getMavenConfig());
-        assertEquals(ImmutableList.of(), loadedNoExtensions.getMavenConfig().getDependencies());
-        assertEquals(ImmutableList.of(), loadedNoExtensions.getMavenConfig().getRepositories());
+        assertEquals(ListUtils.of(), loadedNoExtensions.getMavenConfig().getDependencies());
+        assertEquals(ListUtils.of(), loadedNoExtensions.getMavenConfig().getRepositories());
 
         String noConfiguration = "{\"imports\": [\".\"]}";
         SmithyBuildExtensions loadedNoConfiguration = SmithyBuildLoader.load(DUMMY_PATH, noConfiguration);
         assertNotNull(loadedNoConfiguration.getMavenConfig());
-        assertEquals(ImmutableList.of(), loadedNoConfiguration.getMavenConfig().getDependencies());
-        assertEquals(ImmutableList.of(), loadedNoConfiguration.getMavenConfig().getRepositories());
+        assertEquals(ListUtils.of(), loadedNoConfiguration.getMavenConfig().getDependencies());
+        assertEquals(ListUtils.of(), loadedNoConfiguration.getMavenConfig().getRepositories());
 
         String noRepositories = "{\"mavenDependencies\": [\"a1\", \"a2\"]}";
         SmithyBuildExtensions loadedNoRepositories = SmithyBuildLoader.load(DUMMY_PATH, noRepositories);
         assertNotNull(loadedNoRepositories.getMavenConfig());
-        assertEquals(ImmutableList.of("a1", "a2"), loadedNoRepositories.getMavenConfig().getDependencies());
-        assertEquals(ImmutableList.of(), loadedNoRepositories.getMavenConfig().getRepositories());
+        assertEquals(ListUtils.of("a1", "a2"), loadedNoRepositories.getMavenConfig().getDependencies());
+        assertEquals(ListUtils.of(), loadedNoRepositories.getMavenConfig().getRepositories());
 
         String noArtifacts = "{\"mavenRepositories\": [\"r1\", \"r2\"]}";
         SmithyBuildExtensions loadedNoArtifacts = SmithyBuildLoader.load(DUMMY_PATH, noArtifacts);
         assertNotNull(loadedNoArtifacts.getMavenConfig());
-        assertEquals(ImmutableList.of(), loadedNoArtifacts.getMavenConfig().getDependencies());
-        assertEquals(ImmutableList.of("r1", "r2"), loadedNoArtifacts.getMavenConfig().getRepositories()
+        assertEquals(ListUtils.of(), loadedNoArtifacts.getMavenConfig().getDependencies());
+        assertEquals(ListUtils.of("r1", "r2"), loadedNoArtifacts.getMavenConfig().getRepositories()
                 .stream().map(MavenRepository::getUrl).collect(Collectors.toList()));
     }
 
@@ -86,8 +86,8 @@ public class SmithyBuildExtensionsTest {
                 "[{\"url\": \"r1\"}, {\"url\": \"r2\"}]}, \"mavenRepositories\": [\"m1\", \"m2\"]," +
                 "\"mavenDependencies\": [\"a1\", \"a2\"]}";
         SmithyBuildExtensions loadedConflictingConfig = SmithyBuildLoader.load(DUMMY_PATH, conflictingConfig);
-        assertEquals(ImmutableList.of("d1", "d2"), loadedConflictingConfig.getMavenConfig().getDependencies());
-        assertEquals(ImmutableList.of("r1", "r2"), loadedConflictingConfig.getMavenConfig().getRepositories()
+        assertEquals(ListUtils.of("d1", "d2"), loadedConflictingConfig.getMavenConfig().getDependencies());
+        assertEquals(ListUtils.of("r1", "r2"), loadedConflictingConfig.getMavenConfig().getRepositories()
                 .stream().map(MavenRepository::getUrl).collect(Collectors.toList()));
     }
 
@@ -102,9 +102,9 @@ public class SmithyBuildExtensionsTest {
         SmithyBuildExtensions result = builder.mavenDependencies(Arrays.asList("d1", "d2"))
                 .mavenRepositories(Arrays.asList("r1", "r2")).imports(Arrays.asList("i1", "i2")).merge(other).build();
 
-        assertEquals(ImmutableList.of("d1", "d2", "hello", "world"), result.getMavenConfig().getDependencies());
-        assertEquals(ImmutableList.of("r1", "r2", "hi", "there"), result.getMavenConfig().getRepositories()
+        assertEquals(ListUtils.of("d1", "d2", "hello", "world"), result.getMavenConfig().getDependencies());
+        assertEquals(ListUtils.of("r1", "r2", "hi", "there"), result.getMavenConfig().getRepositories()
                 .stream().map(MavenRepository::getUrl).collect(Collectors.toList()));
-        assertEquals(ImmutableList.of("i1", "i2", "i3", "i4"), result.getImports());
+        assertEquals(ListUtils.of("i1", "i2", "i3", "i4"), result.getImports());
     }
 }

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
@@ -18,7 +18,6 @@ package software.amazon.smithy.lsp.ext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -87,7 +86,7 @@ public class SmithyProjectTest {
         Path baseDir = Paths.get(SmithyProjectTest.class.getResource("models").toURI());
         Path modelMain = baseDir.resolve("main.smithy");
         Path modelTest = baseDir.resolve("test.smithy");
-        List<Path> modelFiles = ImmutableList.of(modelMain, modelTest);
+        List<Path> modelFiles = ListUtils.of(modelMain, modelTest);
 
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
             Map<ShapeId, Location> locationMap = hs.getProject().getLocations();
@@ -137,7 +136,7 @@ public class SmithyProjectTest {
         Path baseDir = Paths.get(SmithyProjectTest.class.getResource("models").toURI());
         Path modelMain = baseDir.resolve("main.smithy");
         Path modelTest = baseDir.resolve("test.smithy");
-        List<Path> modelFiles = ImmutableList.of(modelMain, modelTest);
+        List<Path> modelFiles = ListUtils.of(modelMain, modelTest);
 
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
             SmithyProject project = hs.getProject();

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyTextDocumentServiceTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -175,7 +174,7 @@ public class SmithyTextDocumentServiceTest {
         Path baseDir = Paths.get(SmithyProjectTest.class.getResource("models").toURI());
         String modelFilename = "main.smithy";
         Path modelMain = baseDir.resolve(modelFilename);
-        List<Path> modelFiles = ImmutableList.of(modelMain);
+        List<Path> modelFiles = ListUtils.of(modelMain);
 
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
             SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty(), hs.getTempFolder());
@@ -252,7 +251,7 @@ public class SmithyTextDocumentServiceTest {
         Path baseDir = Paths.get(SmithyProjectTest.class.getResource("models").toURI());
         String modelFilename = "main.smithy";
         Path modelMain = baseDir.resolve(modelFilename);
-        List<Path> modelFiles = ImmutableList.of(modelMain);
+        List<Path> modelFiles = ListUtils.of(modelMain);
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
             SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty(), hs.getTempFolder());
             StubClient client = new StubClient();
@@ -290,7 +289,7 @@ public class SmithyTextDocumentServiceTest {
         Path baseDir = Paths.get(SmithyProjectTest.class.getResource("models").toURI());
         String modelFilename = "main.smithy";
         Path modelMain = baseDir.resolve(modelFilename);
-        List<Path> modelFiles = ImmutableList.of(modelMain);
+        List<Path> modelFiles = ListUtils.of(modelMain);
 
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
             SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty(), hs.getTempFolder());
@@ -316,7 +315,7 @@ public class SmithyTextDocumentServiceTest {
     public void runSelectorAgainstModelWithErrors() throws Exception {
         Path baseDir = Paths.get(SmithyProjectTest.class.getResource("models").toURI());
         Path broken = baseDir.resolve("broken.smithy");
-        List<Path> modelFiles = ImmutableList.of(broken);
+        List<Path> modelFiles = ListUtils.of(broken);
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
             SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty(), hs.getTempFolder());
             StubClient client = new StubClient();


### PR DESCRIPTION
Switches to `ListUtils.of` from `ImmutableList.of`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
