### PR TITLE
Avoid null pointer when printing to log

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
@@ -90,7 +90,7 @@ public final class LspLog {
      * @param message object to write, will be converted to String
      */
     public static void println(Object message) {
-        String sanitizedMessage = message != null ? message.toString : "null";
+        String sanitizedMessage = message != null ? message.toString() : "null";
         String timestamped = "[" + currentTime() + "] " + sanitizedMessage;
         try {
             if (fw != null) {

--- a/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
@@ -90,7 +90,8 @@ public final class LspLog {
      * @param message object to write, will be converted to String
      */
     public static void println(Object message) {
-        String timestamped = "[" + currentTime() + "] " + message.toString();
+        String sanitizedMessage = message != null ? message.toString : "null";
+        String timestamped = "[" + currentTime() + "] " + sanitizedMessage;
         try {
             if (fw != null) {
                 fw.append(timestamped + "\n").flush();


### PR DESCRIPTION
When integrating the vscode extension, I saw this error popup:

```
Caused by: java.lang.NullPointerException: Cannot invoke "Object.toString()" because "message" is null
	at software.amazon.smithy.lsp.ext.LspLog.println(LspLog.java:93)
	at software.amazon.smithy.lsp.SmithyLanguageServer.initialize(SmithyLanguageServer.java:66)
	... 16 more
```