### PR TITLE
Updated smithy model to pick latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ publishing {
 
 dependencies {
     implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.14.0"
-    implementation "software.amazon.smithy:smithy-model:[1.0, 2.0["
+    implementation "software.amazon.smithy:smithy-model:[1.22.0, 2.0["
     implementation 'io.get-coursier:interface:1.0.4'
 
 


### PR DESCRIPTION
https://github.com/awslabs/smithy-language-server/issues/57

Updated dependency to pick the latest version of smithy-model. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
