### PR TITLE
LspLog: one fix, one improvement

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
@@ -110,15 +110,13 @@ public final class LspLog {
     private static String processMessage(Object message) {
         if (message == null) {
             return "null";
+        } else if (message instanceof Throwable) {
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            ((Throwable) message).printStackTrace(pw);
+            return sw.toString();
         } else {
-            if (message instanceof Throwable) {
-                StringWriter sw = new StringWriter();
-                PrintWriter pw = new PrintWriter(sw);
-                ((Throwable) message).printStackTrace(pw);
-                return sw.toString();
-            } else {
-                return message.toString();
-            }
+            return message.toString();
         }
     }
 }

--- a/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
@@ -92,7 +92,7 @@ public final class LspLog {
      * @param message object to write, will be converted to String
      */
     public static void println(Object message) {
-        String sanitizedMessage = processMessage(message);
+        String sanitizedMessage = getStringifiedMessage(message);
         String timestamped = "[" + currentTime() + "] " + sanitizedMessage;
         try {
             if (fw != null) {

--- a/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
@@ -107,7 +107,7 @@ public final class LspLog {
         }
     }
 
-    private static String processMessage(Object message) {
+    private static String getStringifiedMessage(Object message) {
         if (message == null) {
             return "null";
         } else if (message instanceof Throwable) {

--- a/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
@@ -17,9 +17,9 @@ package software.amazon.smithy.lsp.ext;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.io.StringWriter;
-import java.io.PrintWriter;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Paths;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -106,6 +106,7 @@ public final class LspLog {
 
         }
     }
+
     private static String processMessage(Object message) {
         if (message == null) {
             return "null";

--- a/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
@@ -17,6 +17,8 @@ package software.amazon.smithy.lsp.ext;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.StringWriter;
+import java.io.PrintWriter;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.time.LocalTime;
@@ -90,18 +92,32 @@ public final class LspLog {
      * @param message object to write, will be converted to String
      */
     public static void println(Object message) {
-        String sanitizedMessage = message != null ? message.toString() : "null";
+        String sanitizedMessage = processMessage(message);
         String timestamped = "[" + currentTime() + "] " + sanitizedMessage;
         try {
             if (fw != null) {
                 fw.append(timestamped + "\n").flush();
             } else {
                 synchronized (buffer) {
-                    buffer.ifPresent(buf -> buf.add(timestamped));
+                    buffer.ifPresent(buf -> buf.add(sanitizedMessage));
                 }
             }
         } catch (Exception e) {
 
+        }
+    }
+    private static String processMessage(Object message) {
+        if (message == null) {
+            return "null";
+        } else {
+            if (message instanceof Throwable) {
+                StringWriter sw = new StringWriter();
+                PrintWriter pw = new PrintWriter(sw);
+                ((Throwable) message).printStackTrace(pw);
+                return sw.toString();
+            } else {
+                return message.toString();
+            }
         }
     }
 }


### PR DESCRIPTION
1. When the file does not exist the `message` is added to a buffer to eventually be written to the file. When this happens, the `message` is timestamped twice.

2. When println receives an exception, it would be great if the stack trace was printed rather than only the `getMessage`.

This commit address these two things
