### PR TITLE
More gracefully handle unknown traits

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
@@ -54,13 +54,20 @@ public final class SmithyInterface {
         // Contrary to model assemblers, model builders do not complain about the
         // duplication of shapes. Shapes will simply overwrite each other in a "last
         // write wins" kind of way.
-
         URLClassLoader urlClassLoader = new URLClassLoader(urlArray);
-        Model upstreamModel = Model.assembler().discoverModels(urlClassLoader).assemble().unwrap();
+        Model upstreamModel = Model.assembler()
+                .putProperty(ModelAssembler.ALLOW_UNKNOWN_TRAITS, true)
+                .discoverModels(urlClassLoader)
+                .assemble()
+                .unwrap();
         builder.addShapes(upstreamModel);
       }
 
-      ModelAssembler assembler = Model.assembler().addModel(builder.build());
+      ModelAssembler assembler = Model.assembler()
+              // We don't want the model to be broken when there are unknown traits,
+              // because that will essentially disable language server features.
+              .putProperty(ModelAssembler.ALLOW_UNKNOWN_TRAITS, true)
+              .addModel(builder.build());
 
       for (File file : files) {
         assembler = assembler.addImport(file.getAbsolutePath());

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
@@ -83,6 +83,15 @@ public class SmithyProjectTest {
     }
 
     @Test
+    public void ableToLoadWithUnknownTrait() throws Exception {
+        Path modelFile = Paths.get(getClass().getResource("models/unknown-trait.smithy").toURI());
+        try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), ListUtils.of(modelFile))) {
+            ValidatedResult<Model> modelValidatedResult = hs.getProject().getModel();
+            assertFalse(modelValidatedResult.isBroken());
+        }
+    }
+
+    @Test
     public void ignoresUnmodeledApplyStatements() throws Exception {
         Path baseDir = Paths.get(SmithyProjectTest.class.getResource("models/v2").toURI());
         Path main = baseDir.resolve("apply.smithy");

--- a/src/test/resources/software/amazon/smithy/lsp/ext/models/unknown-trait.smithy
+++ b/src/test/resources/software/amazon/smithy/lsp/ext/models/unknown-trait.smithy
@@ -1,0 +1,16 @@
+$version: "2.0"
+
+namespace com.foo
+
+use com.external#unknownTrait
+
+@unknownTrait
+structure Foo {}
+
+structure Bar {
+    member: Foo
+}
+
+structure Baz {
+    member: Bar
+}


### PR DESCRIPTION
*Issue #, if available:* #67
*Description of changes:*
This commit allows hover and jump to definition to continue functioning
when there are unknown traits in the model, and stops crashes when hovering
when there are unknown traits in the model. Additionally, when hovering
over shapes that use an unknown trait, an error message will be displayed in
the hover content. Tests were also added to verify that:
- A model with unknown traits can be loaded
- Diagnostics are still sent for unknown traits
- Definition for valid shapes still works when there are unknown traits
- Hover for valid shapes still works when there are unknown traits
- Error messages are displayed in hover content for invalid shapes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
