### PR TITLE
Add traits, validators from upstream

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
@@ -24,7 +24,9 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import software.amazon.smithy.lsp.ext.LspLog;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.loader.ModelAssembler;
+import software.amazon.smithy.model.traits.TraitFactory;
 import software.amazon.smithy.model.validation.ValidatedResult;
+import software.amazon.smithy.model.validation.ValidatorFactory;
 
 public final class SmithyInterface {
   private SmithyInterface() {


### PR DESCRIPTION
*Description of changes:*

Overrides the trait and validator factories to include instances captured by SPI from `externalJars`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
