### PR TITLE
Bump smithy version to 1.27.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ publishing {
 
 dependencies {
     implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.14.0"
-    implementation "software.amazon.smithy:smithy-model:[1.25.0, 2.0["
+    implementation "software.amazon.smithy:smithy-model:[1.27.0, 2.0["
     implementation 'io.get-coursier:interface:1.0.4'
 
 


### PR DESCRIPTION
Updates the Language Server to use Smithy 1.27.0 or later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
