### PR TITLE
Run CI on Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Java ${{ matrix.java }} ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11]
+        java: [8, 11, 17]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
Adds running CI on Java 17.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
