### PR TITLE
Diagnostic and codeActions for missing/outdated Smithy version

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
@@ -42,6 +43,7 @@ import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
+import software.amazon.smithy.lsp.codeactions.SmithyCodeActions;
 import software.amazon.smithy.lsp.ext.LspLog;
 import software.amazon.smithy.lsp.ext.ValidationException;
 import software.amazon.smithy.utils.ListUtils;
@@ -100,7 +102,7 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
 
     ServerCapabilities capabilities = new ServerCapabilities();
     capabilities.setTextDocumentSync(TextDocumentSyncKind.Full);
-    capabilities.setCodeActionProvider(false);
+    capabilities.setCodeActionProvider(new CodeActionOptions(SmithyCodeActions.all()));
     capabilities.setDefinitionProvider(true);
     capabilities.setDeclarationProvider(true);
     capabilities.setCompletionProvider(new CompletionOptions(true, null));

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -666,13 +666,10 @@ public class SmithyTextDocumentService implements TextDocumentService {
 
     }
 
-    private void clearAllDiagnostics() {
-        List<File> smithyFiles = this.project.getSmithyFiles();
-        report(Either.forRight(
-            createPerFileDiagnostics(this.project.getModel().getValidationEvents(), smithyFiles)
-        ));
+    public void clearAllDiagnostics() {
+        report(Either.forRight(createPerFileDiagnostics(this.project.getModel().getValidationEvents(),
+                this.project.getSmithyFiles())));
     }
-
 
     /**
      * Main recompilation method, responsible for reloading the model, persisting it

--- a/src/main/java/software/amazon/smithy/lsp/Utils.java
+++ b/src/main/java/software/amazon/smithy/lsp/Utils.java
@@ -169,11 +169,37 @@ public final class Utils {
 
     }
 
+    /**
+     * Given a content, split it on new line and extract the first n lines.
+     * @param content content to look at
+     * @param n number of lines to extract
+     * @return list of numbered lines, empty if the content has no newline in it.
+     */
+    public static List<NumberedLine> contentFirstNLines(String content, int n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("n must be greater or equal to 0");
+        }
+
+        if (content == null) {
+            throw new IllegalArgumentException("content must not be null");
+        }
+
+        String[] contentLines = content.split("\n");
+
+        if (contentLines.length == 0) {
+            return Collections.emptyList();
+        }
+
+        return IntStream.range(0, Math.min(n, contentLines.length))
+                 .mapToObj(i -> new NumberedLine(contentLines[i], i))
+                 .collect(Collectors.toList());
+    }
+
     static class NumberedLine {
         private final String content;
         private final int lineNumber;
 
-        public NumberedLine(String content, int lineNumber) {
+        NumberedLine(String content, int lineNumber) {
             this.content = content;
             this.lineNumber = lineNumber;
         }

--- a/src/main/java/software/amazon/smithy/lsp/Utils.java
+++ b/src/main/java/software/amazon/smithy/lsp/Utils.java
@@ -106,7 +106,7 @@ public final class Utils {
 
     /**
      * @param rawUri the uri to a file in a jar.
-     * @return the lines of of the file in a jar
+     * @return the lines of the file in a jar
      * @throws IOException when rawUri cannot be URI-decoded.
      */
     public static List<String> jarFileContents(String rawUri) throws IOException {

--- a/src/main/java/software/amazon/smithy/lsp/Utils.java
+++ b/src/main/java/software/amazon/smithy/lsp/Utils.java
@@ -195,7 +195,7 @@ public final class Utils {
                  .collect(Collectors.toList());
     }
 
-    static class NumberedLine {
+    public static class NumberedLine {
         private final String content;
         private final int lineNumber;
 

--- a/src/main/java/software/amazon/smithy/lsp/Utils.java
+++ b/src/main/java/software/amazon/smithy/lsp/Utils.java
@@ -22,11 +22,16 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.zip.ZipEntry;
 
 public final class Utils {
@@ -138,4 +143,47 @@ public final class Utils {
         return pathArray[0];
     }
 
+
+    /**
+     * Read only the first N lines of a file.
+     * @param file file to read
+     * @param n number of lines to read, must be >= 0. if n is 3, we'll return lines 0, 1, 2
+     * @return list of numbered lines, empty if the file does not exist or
+     * is empty.
+     */
+    public static List<NumberedLine> readFirstNLines(File file, int n) throws IOException {
+        if (n < 0) {
+            throw new IllegalArgumentException("n must be greater or equal to 0");
+        }
+
+        Path filePath = file.toPath();
+        if (!Files.exists(filePath)) {
+            return Collections.emptyList();
+        }
+
+        final ArrayList<NumberedLine> list = new ArrayList<>();
+        try (BufferedReader reader = Files.newBufferedReader(filePath, StandardCharsets.UTF_8)) {
+            reader.lines().limit(n).forEach(s -> list.add(new NumberedLine(s, list.size())));
+        }
+        return list;
+
+    }
+
+    static class NumberedLine {
+        private final String content;
+        private final int lineNumber;
+
+        public NumberedLine(String content, int lineNumber) {
+            this.content = content;
+            this.lineNumber = lineNumber;
+        }
+
+        public String getContent() {
+            return content;
+        }
+
+        public int getLineNumber() {
+            return lineNumber;
+        }
+    }
 }

--- a/src/main/java/software/amazon/smithy/lsp/codeactions/DefineVersionCodeAction.java
+++ b/src/main/java/software/amazon/smithy/lsp/codeactions/DefineVersionCodeAction.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.lsp.codeactions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WorkspaceEdit;
+
+
+public final class DefineVersionCodeAction {
+    private static final int DEFAULT_VERSION = 1;
+
+    private DefineVersionCodeAction() {
+
+    }
+
+    /**
+     * Build a CodeAction instance that will add a $version statement at
+     * the top of the file.
+     * @param fileUri path to the file to update
+     * @return a CodeAction with a single TextEdit in it
+     */
+    public static CodeAction build(String fileUri) {
+        CodeAction codeAction = new CodeAction("Define the Smithy version");
+        codeAction.setKind(SmithyCodeActions.SMITHY_DEFINE_VERSION);
+        WorkspaceEdit wEdit = new WorkspaceEdit();
+        TextEdit edit = new TextEdit(
+            new Range(new Position(0, 0), new Position(0, 0)),
+            "$version: \"" + DEFAULT_VERSION + "\"\n\n"
+        );
+        Map<String, List<TextEdit>> changes = Collections.singletonMap(fileUri, Collections.singletonList(edit));
+        wEdit.setChanges(changes);
+        codeAction.setEdit(wEdit);
+        return codeAction;
+    }
+}

--- a/src/main/java/software/amazon/smithy/lsp/codeactions/SmithyCodeActions.java
+++ b/src/main/java/software/amazon/smithy/lsp/codeactions/SmithyCodeActions.java
@@ -15,8 +15,15 @@
 
 package software.amazon.smithy.lsp.codeactions;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Diagnostic;
+import software.amazon.smithy.lsp.diagnostics.VersionDiagnostics;
 
 public final class SmithyCodeActions {
     public static final String SMITHY_UPDATE_VERSION = "smithyUpdateVersion";
@@ -28,5 +35,46 @@ public final class SmithyCodeActions {
 
     public static List<String> all() {
         return Arrays.asList(SMITHY_UPDATE_VERSION, SMITHY_DEFINE_VERSION);
+    }
+
+    /**
+     * Given the `CodeActionParams` argument, compute a list of {@link CodeAction} that
+     * are available related to the `$version` statement.
+     *
+     * Actions include:
+     * * defining the version
+     * * updating the version
+     *
+     * This particular implementation relies on specific {@link Diagnostic} to be available through the
+     * {@link CodeActionParams}.
+     * @param params {@link CodeActionParams} coming from
+     * {@link org.eclipse.lsp4j.services.TextDocumentService#codeAction(CodeActionParams)}
+     * @return a list of {@link CodeAction} that can be applied
+     */
+    public static List<CodeAction> versionCodeActions(CodeActionParams params) {
+        ArrayList<CodeAction> actions = new ArrayList<>();
+
+        String fileUri = params.getTextDocument().getUri();
+        boolean defineVersion = params.getContext().getDiagnostics().stream()
+                .anyMatch(diagnosticCodePredicate(VersionDiagnostics.SMITHY_DEFINE_VERSION));
+        if (defineVersion) {
+            actions.add(DefineVersionCodeAction.build(fileUri));
+        }
+        Optional<Diagnostic> updateVersionDiagnostic = params.getContext().getDiagnostics().stream()
+                .filter(diagnosticCodePredicate(VersionDiagnostics.SMITHY_UPDATE_VERSION)).findFirst();
+        if (updateVersionDiagnostic.isPresent()) {
+            actions.add(
+                UpdateVersionCodeAction.build(fileUri, updateVersionDiagnostic.get().getRange())
+            );
+        }
+
+        return actions;
+    }
+
+    private static Predicate<Diagnostic> diagnosticCodePredicate(String code) {
+        return d ->
+                d.getCode() != null
+                        && d.getCode().isLeft()
+                        && d.getCode().getLeft().equals(code);
     }
 }

--- a/src/main/java/software/amazon/smithy/lsp/codeactions/SmithyCodeActions.java
+++ b/src/main/java/software/amazon/smithy/lsp/codeactions/SmithyCodeActions.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.lsp.codeactions;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class SmithyCodeActions {
+    public static final String SMITHY_UPDATE_VERSION = "smithyUpdateVersion";
+    public static final String SMITHY_DEFINE_VERSION = "smithyDefineVersion";
+
+    private SmithyCodeActions() {
+
+    }
+
+    public static List<String> all() {
+        return Arrays.asList(SMITHY_UPDATE_VERSION, SMITHY_DEFINE_VERSION);
+    }
+}

--- a/src/main/java/software/amazon/smithy/lsp/codeactions/UpdateVersionCodeAction.java
+++ b/src/main/java/software/amazon/smithy/lsp/codeactions/UpdateVersionCodeAction.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.lsp.codeactions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WorkspaceEdit;
+
+public final class UpdateVersionCodeAction {
+    private static final int LATEST_VERSION = 2;
+
+    private UpdateVersionCodeAction() {
+
+    }
+
+    /**
+     * Build a CodeAction instance that will update the $version statement at of a file.
+     * @param fileUri path to the file to update
+     * @param versionStatementRange ranger where the $version statement is defined
+     * @return a CodeAction with a single TextEdit in it
+     */
+    public static CodeAction build(String fileUri, Range versionStatementRange) {
+        CodeAction codeAction = new CodeAction("Update the Smithy version to " + LATEST_VERSION);
+        codeAction.setKind(SmithyCodeActions.SMITHY_UPDATE_VERSION);
+        WorkspaceEdit wEdit = new WorkspaceEdit();
+        TextEdit edit = new TextEdit(versionStatementRange, "$version: \"" + LATEST_VERSION + "\"");
+        Map<String, List<TextEdit>> changes = Collections.singletonMap(fileUri, Collections.singletonList(edit));
+        wEdit.setChanges(changes);
+        codeAction.setEdit(wEdit);
+        return codeAction;
+    }
+}

--- a/src/main/java/software/amazon/smithy/lsp/diagnostics/VersionDiagnostics.java
+++ b/src/main/java/software/amazon/smithy/lsp/diagnostics/VersionDiagnostics.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.lsp.diagnostics;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticCodeDescription;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Range;
+
+public final class VersionDiagnostics {
+    public static final String SMITHY_UPDATE_VERSION = "migrating-idl-1-to-2";
+    public static final String SMITHY_DEFINE_VERSION = "define-idl-version";
+
+    private static final DiagnosticCodeDescription SMITHY_UPDATE_VERSION_CODE_DIAGNOSTIC =
+            new DiagnosticCodeDescription("https://smithy.io/2.0/guides/migrating-idl-1-to-2.html");
+
+    private VersionDiagnostics() {
+
+    }
+
+    private static Diagnostic build(String title, String code, Range range) {
+        return new Diagnostic(
+            range,
+            title,
+            DiagnosticSeverity.Warning,
+            "Smithy LSP",
+            code
+        );
+    }
+
+    /**
+     * Build a diagnostic for an outdated Smithy version.
+     * @param range range where the $version statement is found
+     * @return a Diagnostic with a code that refer to the codeAction to take
+     */
+    public static Diagnostic updateVersion(Range range) {
+        Diagnostic diag = build(
+            "You can upgrade to version 2.",
+            SMITHY_UPDATE_VERSION,
+            range
+        );
+        diag.setCodeDescription(SMITHY_UPDATE_VERSION_CODE_DIAGNOSTIC);
+        return diag;
+    }
+
+    /**
+     * Build a diagnostic for a missing Smithy version.
+     * @param range range where the $version is expected to be
+     * @return a Diagnostic with a code that refer to the codeAction to take
+     */
+    public static Diagnostic defineVersion(Range range) {
+        return build(
+            "You should define a version for your Smithy file.",
+            SMITHY_DEFINE_VERSION,
+            range
+        );
+    }
+}

--- a/src/main/java/software/amazon/smithy/lsp/diagnostics/VersionDiagnostics.java
+++ b/src/main/java/software/amazon/smithy/lsp/diagnostics/VersionDiagnostics.java
@@ -15,10 +15,20 @@
 
 package software.amazon.smithy.lsp.diagnostics;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticCodeDescription;
 import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import software.amazon.smithy.lsp.Utils;
 
 public final class VersionDiagnostics {
     public static final String SMITHY_UPDATE_VERSION = "migrating-idl-1-to-2";
@@ -67,5 +77,62 @@ public final class VersionDiagnostics {
             SMITHY_DEFINE_VERSION,
             range
         );
+    }
+
+
+    /**
+     * Produces a diagnostic for each file which w/o a `$version` control statement or
+     * file which have a `$version` control statement, but it is out dated.
+     *
+     * Before looking into a file, we look into `temporaryContents` to make sure
+     * it's not an open buffer currently being modified. If it is, we should use this content
+     * rather than what's on disk for this specific file. This avoids showing diagnostic for
+     * content that's on disk but different from what's in the buffer.
+     *
+     * @param f a smithy file to inspect
+     * @param temporaryContents a map of file to content (represent opened file that are not saved)
+     * @return a list of PublishDiagnosticsParams
+     */
+    public static List<Diagnostic> createVersionDiagnostics(File f, Map<File, String> temporaryContents) {
+        // number of line to read in which we expect the $version statement
+        int n = 5;
+        String editedContent = temporaryContents.get(f);
+
+        List<Utils.NumberedLine> lines;
+        try {
+            lines = editedContent == null ? Utils.readFirstNLines(f, n) : Utils.contentFirstNLines(editedContent, n);
+        } catch (IOException e) {
+            return Collections.emptyList();
+        }
+
+        Optional<Utils.NumberedLine> version =
+            lines.stream().filter(nl -> nl.getContent().startsWith("$version")).findFirst();
+        Stream<Diagnostic> diagStream = version.map(nl -> {
+            // version is set, its 1
+            if (nl.getContent().contains("\"1\"")) {
+                return Stream.of(
+                    VersionDiagnostics.updateVersion(
+                        new Range(
+                            new Position(nl.getLineNumber(), 0),
+                            new Position(nl.getLineNumber(), nl.getContent().length())
+                        )
+                    )
+                );
+            } else {
+                // version is set, it is not 1
+                return Stream.<Diagnostic>empty();
+            }
+        }).orElseGet(() -> {
+            // we use the first line to show the diagnostic, as the $version is at the top of the file
+            // if 0 is used, only the first _word_ is highlighted by the IDE(vscode). It also means that
+            // you can only apply the code action if you position your cursor at the very start of the file.
+            Integer firstLineLength = lines.stream()
+                .findFirst().map(nl -> nl.getContent().length())
+                .orElse(0);
+            return Stream.of(// version is not set
+                VersionDiagnostics.defineVersion(new Range(new Position(0, 0), new Position(0, firstLineLength)))
+            );
+        });
+        return diagStream.collect(Collectors.toList());
     }
 }

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -78,19 +79,19 @@ public final class SmithyProject {
      * @return either an error, or a loaded project.
      */
     public Either<Exception, SmithyProject> recompile(File changed, File exclude) {
-        List<File> newFiles = new ArrayList<>();
+        HashSet<File> fileSet = new HashSet<>();
 
         for (File existing : onlyExistingFiles(this.smithyFiles)) {
             if (exclude != null && !existing.equals(exclude)) {
-                newFiles.add(existing);
+                fileSet.add(existing);
             }
         }
 
         if (changed.isFile()) {
-            newFiles.add(changed);
+            fileSet.add(changed);
         }
 
-        return load(this.imports, newFiles, this.externalJars, this.root);
+        return load(this.imports, new ArrayList<>(fileSet), this.externalJars, this.root);
     }
 
     public ValidatedResult<Model> getModel() {

--- a/src/test/java/software/amazon/smithy/lsp/SmithyLanguageServerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/SmithyLanguageServerTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
+
+import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
@@ -17,6 +19,7 @@ import org.eclipse.lsp4j.WorkspaceFolder;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
+import software.amazon.smithy.lsp.codeactions.SmithyCodeActions;
 import software.amazon.smithy.utils.ListUtils;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -33,7 +36,7 @@ public class SmithyLanguageServerTest {
 
         assertNull(languageServer.tempWorkspaceRoot);
         assertEquals(TextDocumentSyncKind.Full, capabilities.getTextDocumentSync().getLeft());
-        assertFalse(capabilities.getCodeActionProvider().getLeft());
+        assertEquals(new CodeActionOptions(SmithyCodeActions.all()), capabilities.getCodeActionProvider().getRight());
         assertTrue(capabilities.getDefinitionProvider().getLeft());
         assertTrue(capabilities.getDeclarationProvider().getLeft());
         assertEquals(new CompletionOptions(true, null), capabilities.getCompletionProvider());

--- a/src/test/java/software/amazon/smithy/lsp/SmithyTextDocumentServiceTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/SmithyTextDocumentServiceTest.java
@@ -75,8 +75,8 @@ public class SmithyTextDocumentServiceTest {
         String goodFileName = "good.smithy";
 
         Map<String, String> files = MapUtils.ofEntries(
-                MapUtils.entry(brokenFileName, "namespace testFoo\n string_ MyId"),
-                MapUtils.entry(goodFileName, "namespace testBla"));
+                MapUtils.entry(brokenFileName, "$version: \"2\"\nnamespace testFoo\n string_ MyId"),
+                MapUtils.entry(goodFileName, "$version: \"2\"\nnamespace testBla"));
 
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
             SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty(), hs.getTempFolder());
@@ -107,8 +107,8 @@ public class SmithyTextDocumentServiceTest {
         String goodFileName = "good.smithy";
 
         Map<String, String> files = MapUtils.ofEntries(
-                MapUtils.entry(brokenFileName, "namespace testFoo; string_ MyId"),
-                MapUtils.entry(goodFileName, "namespace testBla"));
+                MapUtils.entry(brokenFileName, "$version: \"2\"\nnamespace testFoo; string_ MyId"),
+                MapUtils.entry(goodFileName, "$version: \"2\"\nnamespace testBla"));
 
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
             SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty(), hs.getTempFolder());

--- a/src/test/java/software/amazon/smithy/lsp/SmithyTextDocumentServiceTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/SmithyTextDocumentServiceTest.java
@@ -124,13 +124,13 @@ public class SmithyTextDocumentServiceTest {
             tds.didOpen(new DidOpenTextDocumentParams(textDocumentItem(broken, files.get(brokenFileName))));
 
             // broken file has a diagnostic published against it
-            assertEquals(1, fileDiagnostics(broken, client.diagnostics).size());
+            assertEquals(1, filePublishedDiagnostics(broken, client.diagnostics).size());
             assertEquals(ListUtils.of(DiagnosticSeverity.Error), getSeverities(broken, client.diagnostics));
             // To clear diagnostics correctly, we must *explicitly* publish an empty
             // list of diagnostics against files with no errors
 
-            assertEquals(1, fileDiagnostics(good, client.diagnostics).size());
-            assertEquals(ListUtils.of(), fileDiagnostics(good, client.diagnostics).get(0).getDiagnostics());
+            assertEquals(1, filePublishedDiagnostics(good, client.diagnostics).size());
+            assertEquals(ListUtils.of(), filePublishedDiagnostics(good, client.diagnostics).get(0).getDiagnostics());
 
             client.clear();
 
@@ -139,12 +139,12 @@ public class SmithyTextDocumentServiceTest {
             tds.didSave(new DidSaveTextDocumentParams(new TextDocumentIdentifier(uri(broken))));
 
             // broken file has a diagnostic published against it
-            assertEquals(1, fileDiagnostics(broken, client.diagnostics).size());
+            assertEquals(1, filePublishedDiagnostics(broken, client.diagnostics).size());
             assertEquals(ListUtils.of(DiagnosticSeverity.Error), getSeverities(broken, client.diagnostics));
             // To clear diagnostics correctly, we must *explicitly* publish an empty
             // list of diagnostics against files with no errors
-            assertEquals(1, fileDiagnostics(good, client.diagnostics).size());
-            assertEquals(ListUtils.of(), fileDiagnostics(good, client.diagnostics).get(0).getDiagnostics());
+            assertEquals(1, filePublishedDiagnostics(good, client.diagnostics).size());
+            assertEquals(ListUtils.of(), filePublishedDiagnostics(good, client.diagnostics).get(0).getDiagnostics());
 
         }
 
@@ -829,6 +829,40 @@ public class SmithyTextDocumentServiceTest {
         }
     }
 
+    @Test
+    public void ensureVersionDiagnostic() throws Exception {
+        String fileName1 = "no-version.smithy";
+        String fileName2 = "old-version.smithy";
+        String fileName3 = "good-version.smithy";
+
+        Map<String, String> files = MapUtils.ofEntries(
+                MapUtils.entry(fileName1, "namespace test"),
+                MapUtils.entry(fileName2, "$version: \"1\"\nnamespace test2"),
+                MapUtils.entry(fileName3, "$version: \"2\"\nnamespace test3")
+        );
+
+        try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
+            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.empty(), hs.getTempFolder());
+            StubClient client = new StubClient();
+            tds.createProject(hs.getConfig(), hs.getRoot());
+            tds.setClient(client);
+
+            tds.didOpen(new DidOpenTextDocumentParams(textDocumentItem(hs.file(fileName1), files.get(fileName1))));
+            assertEquals(1, fileDiagnostics(hs.file(fileName1), client.diagnostics).size());
+
+            client.clear();
+
+            tds.didOpen(new DidOpenTextDocumentParams(textDocumentItem(hs.file(fileName2), files.get(fileName2))));
+            assertEquals(1, fileDiagnostics(hs.file(fileName2), client.diagnostics).size());
+
+            client.clear();
+
+            tds.didOpen(new DidOpenTextDocumentParams(textDocumentItem(hs.file(fileName3), files.get(fileName3))));
+            assertEquals(0, fileDiagnostics(hs.file(fileName3), client.diagnostics).size());
+        }
+
+    }
+
     private static class StubClient implements LanguageClient {
         public List<PublishDiagnosticsParams> diagnostics = new ArrayList<>();
         public List<MessageParams> shown = new ArrayList<>();
@@ -875,12 +909,17 @@ public class SmithyTextDocumentServiceTest {
         return diagnostics.stream().map(PublishDiagnosticsParams::getUri).collect(Collectors.toSet());
     }
 
-    private List<PublishDiagnosticsParams> fileDiagnostics(File f, List<PublishDiagnosticsParams> diags) {
+    private List<PublishDiagnosticsParams> filePublishedDiagnostics(File f, List<PublishDiagnosticsParams> diags) {
         return diags.stream().filter(pds -> pds.getUri().equals(uri(f))).collect(Collectors.toList());
     }
 
+    private List<Diagnostic> fileDiagnostics(File f, List<PublishDiagnosticsParams> diags) {
+        return diags.stream().filter(pds -> pds.getUri().equals(uri(f))).flatMap(pd -> pd.getDiagnostics().stream())
+                .collect(Collectors.toList());
+    }
+
     private List<DiagnosticSeverity> getSeverities(File f, List<PublishDiagnosticsParams> diags) {
-        return fileDiagnostics(f, diags).stream()
+        return filePublishedDiagnostics(f, diags).stream()
                 .flatMap(pds -> pds.getDiagnostics().stream().map(Diagnostic::getSeverity)).collect(Collectors.toList());
     }
 

--- a/src/test/java/software/amazon/smithy/lsp/SmithyVersionRefactoringTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/SmithyVersionRefactoringTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.lsp;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionContext;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.junit.Test;
+import software.amazon.smithy.lsp.codeactions.SmithyCodeActions;
+import software.amazon.smithy.lsp.diagnostics.VersionDiagnostics;
+import software.amazon.smithy.lsp.ext.Harness;
+import software.amazon.smithy.lsp.ext.model.SmithyBuildExtensions;
+import software.amazon.smithy.utils.MapUtils;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This test suite test the generation of the correct {@link CodeAction} given {@link CodeActionParams}
+ * but also the generation of the right version {@link org.eclipse.lsp4j.Diagnostic} given a file with
+ * some content in it.
+ */
+public class SmithyVersionRefactoringTest {
+
+    @Test
+    public void noVersionCodeAction() throws Exception {
+        String filename = "no-version.smithy";
+
+        Map<String, String> files = MapUtils.ofEntries(
+            MapUtils.entry(filename, "namespace test")
+        );
+
+        try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
+            Range range0 = new Range(new Position(0, 0), new Position(0, 0));
+
+            CodeActionParams params = new CodeActionParams(
+                new TextDocumentIdentifier(hs.file(filename).toURI().toString()),
+                range0,
+                new CodeActionContext(VersionDiagnostics.createVersionDiagnostics(hs.file(filename), Collections.emptyMap()))
+            );
+            List<CodeAction> result = SmithyCodeActions.versionCodeActions(params);
+            assertEquals(1, result.size());
+            assertEquals("Define the Smithy version", result.get(0).getTitle());
+            // range is (0,0)
+            assertEquals(range0, result.get(0).getEdit().getChanges().values().stream().findFirst().get().get(0).getRange());
+        }
+    }
+
+    @Test
+    public void outdatedVersionCodeAction() throws Exception {
+        String filename = "old-version.smithy";
+
+        Map<String, String> files = MapUtils.ofEntries(
+            MapUtils.entry(filename, "$version: \"1\"\nnamespace test2")
+        );
+
+        try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
+            Range range0 = new Range(new Position(0, 0), new Position(0, 0));
+
+            Range firstLineRange = new Range(new Position(0, 0), new Position(0, 13));
+            CodeActionParams params = new CodeActionParams(
+                new TextDocumentIdentifier(hs.file(filename).toURI().toString()),
+                range0,
+                new CodeActionContext(VersionDiagnostics.createVersionDiagnostics(hs.file(filename), Collections.emptyMap()))
+            );
+            List<CodeAction> result = SmithyCodeActions.versionCodeActions(params);
+            assertEquals(1, result.size());
+            assertEquals("Update the Smithy version to 2", result.get(0).getTitle());
+            // range is where the diagnostic is found
+            assertEquals(firstLineRange, result.get(0).getEdit().getChanges().values().stream().findFirst().get().get(0).getRange());
+        }
+    }
+
+    @Test
+    public void correctVersionCodeAction() throws Exception {
+        String filename = "version.smithy";
+
+        Map<String, String> files = MapUtils.ofEntries(
+            MapUtils.entry(filename, "$version: \"2\"\nnamespace test2")
+        );
+
+        try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), files)) {
+            Range range0 = new Range(new Position(0, 0), new Position(0, 0));
+
+            CodeActionParams params = new CodeActionParams(
+                new TextDocumentIdentifier(hs.file(filename).toURI().toString()),
+                range0,
+                new CodeActionContext(VersionDiagnostics.createVersionDiagnostics(hs.file(filename), Collections.emptyMap()))
+            );
+            List<CodeAction> result = SmithyCodeActions.versionCodeActions(params);
+            assertEquals(0, result.size());
+        }
+    }
+}

--- a/src/test/java/software/amazon/smithy/lsp/codeactions/SmithyCodeActionsTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/codeactions/SmithyCodeActionsTest.java
@@ -1,4 +1,0 @@
-import junit.framework.TestCase;
-public class SmithyCodeActionsTest extends TestCase {
-  
-}

--- a/src/test/java/software/amazon/smithy/lsp/codeactions/SmithyCodeActionsTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/codeactions/SmithyCodeActionsTest.java
@@ -1,0 +1,4 @@
+import junit.framework.TestCase;
+public class SmithyCodeActionsTest extends TestCase {
+  
+}


### PR DESCRIPTION
We were wondering what would be a good way to push users towards adding the `$version` statement in their Smithy file. By default, if it's missing, smithy-model assumes `1`. But most Smithy files could be using `2` so we discussed a way to have this in the IDE.

The flow is basically: if you don't have a version, we suggest/help to define it explicitly (to 1), and if you use version 1, we suggest/help to update it to 2.

The end result looks like this in VS Code:

https://user-images.githubusercontent.com/5230460/212099585-8f00378d-e1b5-495a-b3f2-c78b2cca5ebf.mov

It works by:

1. publishing a diagnostic if the version is missing
2. publishing a diagnostic if the version is found but it contains an older version (`1` here)
3. implement codeAction to generate `TextEdit` if the diagnostic above are found

For 1, and 2, we read the top part of the Smithy file (in this PR I read 5 lines but this is an arbitrary amount). Then we look for a line starting with `$version`. If not found we publish a diagnostic, if found but equal to 1, we publish a diagnostic.

Those diagnostic are added on top of any diagnostic generated from validating the model.

The `TextEdit` are simple:
- rewrite the version if it is found (we can reuse the range from the diagnostic to build the `TextEdit`)
- append `$version: "1"` at the top of the file, explicitly setting the version for the user

------

On top of that, this PR includes (those could be separated PRs):

- a typo fix in some java doc
- a fix when using `findToken` on an empty document