### PR TITLE
Formatting Smithy document

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,7 @@ dependencies {
     implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.14.0"
     implementation "software.amazon.smithy:smithy-model:[1.27.0, 2.0["
     implementation 'io.get-coursier:interface:1.0.4'
-
+    implementation 'com.disneystreaming.smithy:smithytranslate-formatter-jvm-java-api:0.3.2'
 
     // Use JUnit test framework
     testImplementation "junit:junit:4.13"

--- a/build.gradle
+++ b/build.gradle
@@ -217,6 +217,7 @@ jar {
         exclude "META-INF/*.SF"
         exclude "META-INF/*.DSA"
         exclude "META-INF/*.RSA"
+        exclude "reflect.properties"
     }
     manifest {
         attributes("Main-Class": "software.amazon.smithy.lsp.Main")

--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -107,6 +107,7 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
     capabilities.setDeclarationProvider(true);
     capabilities.setCompletionProvider(new CompletionOptions(true, null));
     capabilities.setHoverProvider(true);
+    capabilities.setDocumentFormattingProvider(true);
 
     return Utils.completableFuture(new InitializeResult(capabilities));
   }

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -48,6 +48,7 @@ import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.DocumentFormattingParams;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.Location;
@@ -57,13 +58,18 @@ import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
+import smithyfmt.Formatter;
+import smithyfmt.Result;
 import software.amazon.smithy.lsp.codeactions.SmithyCodeActions;
 import software.amazon.smithy.lsp.diagnostics.VersionDiagnostics;
+import software.amazon.smithy.lsp.editor.SmartInput;
 import software.amazon.smithy.lsp.ext.Completions;
 import software.amazon.smithy.lsp.ext.Constants;
 import software.amazon.smithy.lsp.ext.Document;
@@ -578,6 +584,43 @@ public class SmithyTextDocumentService implements TextDocumentService {
         File file = fileUri(params.getTextDocument());
         stableContents(file);
         report(recompile(file, Optional.empty()));
+    }
+
+    @Override
+    public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
+        File file = fileUri(params.getTextDocument());
+        final CompletableFuture<List<? extends TextEdit>> emptyResult =
+            Utils.completableFuture(Collections.emptyList());
+
+        final Optional<SmartInput> content = Utils.optOr(
+                Optional.ofNullable(temporaryContents.get(file)).map(SmartInput::fromInput),
+                () -> SmartInput.fromPathSafe(file.toPath())
+        );
+        if (content.isPresent()) {
+            SmartInput input = content.get();
+            // if last character is not a new line, make it so
+            // work around an issue where the grammar requires a BR after
+            // each shape statement
+            final String finalContent = input.getInput().charAt(input.getInput().length() - 1) == '\n'
+                ? input.getInput()
+                : input.getInput() + "\n";
+            final Result result = Formatter.format(finalContent);
+            final Range fullRange = input.getRange();
+            if (result.isSuccess() && !result.getValue().equals(input.getInput())) {
+                return Utils.completableFuture(Collections.singletonList(new TextEdit(
+                        fullRange,
+                        result.getValue()
+                )));
+            } else if (!result.isSuccess()) {
+                LspLog.println("Failed to format: " + result.getError());
+                return emptyResult;
+            } else {
+                return emptyResult;
+            }
+        } else {
+            LspLog.println("Content is unavailable, not formatting.");
+            return emptyResult;
+        }
     }
 
     private File fileUri(TextDocumentIdentifier tdi) {

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -598,13 +598,7 @@ public class SmithyTextDocumentService implements TextDocumentService {
         );
         if (content.isPresent()) {
             SmartInput input = content.get();
-            // if last character is not a new line, make it so
-            // work around an issue where the grammar requires a BR after
-            // each shape statement
-            final String finalContent = input.getInput().charAt(input.getInput().length() - 1) == '\n'
-                ? input.getInput()
-                : input.getInput() + "\n";
-            final Result result = Formatter.format(finalContent);
+            final Result result = Formatter.format(input.getInput());
             final Range fullRange = input.getRange();
             if (result.isSuccess() && !result.getValue().equals(input.getInput())) {
                 return Utils.completableFuture(Collections.singletonList(new TextEdit(

--- a/src/main/java/software/amazon/smithy/lsp/Utils.java
+++ b/src/main/java/software/amazon/smithy/lsp/Utils.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import java.util.jar.JarFile;
@@ -210,6 +211,20 @@ public final class Utils {
 
         public int getLineNumber() {
             return lineNumber;
+        }
+    }
+
+    /**
+     * Helper to provide an alternative Optional if the first is empty.
+     * @param o1 first optional
+     * @param o2get supplier to retrieve the second optional
+     * @return the first optional if not empty, otherwise get the second optional
+     */
+    public static <T> Optional<T> optOr(Optional<T> o1, Supplier<Optional<T>> o2get) {
+        if (o1.isPresent()) {
+            return o1;
+        } else {
+            return o2get.get();
         }
     }
 }

--- a/src/main/java/software/amazon/smithy/lsp/editor/SmartInput.java
+++ b/src/main/java/software/amazon/smithy/lsp/editor/SmartInput.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.lsp.editor;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+public final class SmartInput {
+    public static final Position POS_0_0 = new Position(0, 0);
+    private final String input;
+    private final Range range;
+
+    private SmartInput(List<String> lines) {
+        Position endPos;
+        if (lines.isEmpty()) {
+            endPos = POS_0_0;
+        } else {
+            final int lastLineI = lines.size() - 1;
+            final String lastLine = lines.get(lastLineI);
+            endPos = new Position(lastLineI, lastLine.length());
+        }
+        this.input = String.join("\n", lines);
+        this.range = new Range(POS_0_0, endPos);
+    }
+
+    /**
+     * Read the file at `p`.
+     * @param p path to the file to read
+     * @return the content if no exception occurs, otherwise throws.
+     */
+    public static SmartInput fromPath(Path p) throws IOException {
+        return fromInput(new String(Files.readAllBytes(p), StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Read the file at `p` and wrap it into an Optional.
+     * @param p path to the file to read
+     * @return Optional with the content if no exception occurs, otherwise Optional.empty.
+     */
+    public static Optional<SmartInput> fromPathSafe(Path p) {
+        try {
+            return Optional.of(fromPath(p));
+        } catch (IOException e) {
+            return Optional.empty();
+        }
+    }
+
+    public static SmartInput fromInput(String input) {
+        String[] split = input.split("\\n", -1); // keep trailing new lines
+        return new SmartInput(Arrays.asList(split));
+    }
+
+    public String getInput() {
+        return input;
+    }
+
+    public Range getRange() {
+        return range;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SmartInput that = (SmartInput) o;
+        return input.equals(that.input) && range.equals(that.range);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(input, range);
+    }
+
+    @Override
+    public String toString() {
+        return "SmartInput{" + "input='" + input + '\'' + ", range=" + range + '}';
+    }
+}

--- a/src/main/java/software/amazon/smithy/lsp/editor/SmartInput.java
+++ b/src/main/java/software/amazon/smithy/lsp/editor/SmartInput.java
@@ -1,16 +1,6 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package software.amazon.smithy.lsp.editor;


### PR DESCRIPTION
Recently, we made great progress on our Smithy parser. We were able to build a formatter to go along with it. This PR adds formatting capability to the language server implementation. Formatting happens when the client requests it. For example in VS Code:

1. explicitly ask to format a file
2. configure format on save - editor calls format before calling save

Here is a small demo:


https://user-images.githubusercontent.com/5230460/222233725-493e8b45-bb30-485c-84de-9e45ebac9ba1.mov

