### PR TITLE
Upgrade smithytranslate formatter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,7 @@ dependencies {
     implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.14.0"
     implementation "software.amazon.smithy:smithy-model:[1.27.0, 2.0["
     implementation 'io.get-coursier:interface:1.0.4'
-    implementation 'com.disneystreaming.smithy:smithytranslate-formatter-jvm-java-api:0.3.2'
+    implementation 'com.disneystreaming.smithy:smithytranslate-formatter-jvm-java-api:0.3.3'
 
     // Use JUnit test framework
     testImplementation "junit:junit:4.13"


### PR DESCRIPTION
Upgrade formatter to `0.3.3` to pick up change from https://github.com/disneystreaming/smithy-translate/pull/102.

See https://github.com/awslabs/smithy-language-server/pull/89#issuecomment-1463956264.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
