### PR TITLE
Fix changelog year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Smithy Language Server Changelog
 
-## 0.2.3 (2022-03-15)
+## 0.2.3 (2023-03-15)
 
 ### Features
 * Added formatter to apply style guide to model files ([#89](https://github.com/awslabs/smithy-language-server/pull/89))


### PR DESCRIPTION
Fix year in CHANGELOG entry for 0.2.3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
