### PR TITLE
Add github release task

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+---
+
+name: deploy
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  deploy:
+    permissions:
+      contents: write # needed for the release script
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set variables
+        run: |
+          VER=$(cat VERSION)
+          echo "VERSION=$VER" >> $GITHUB_ENV
+          echo "Version is $VER"
+
+      - name: Setup JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: "11"
+
+      - name: Clean and build
+        run: ./gradlew clean build distZip
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ./build/distributions/smithy-language-server-${{ env.VERSION }}.zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ name: deploy
 on:
   push:
     tags:
-      - "v*"
+      - "0*"
 
 jobs:
   deploy:


### PR DESCRIPTION
*Description of changes:*

Adds a GitHub action to create a release each time a new tag is pushed. This change is made with the intention of making the language server more accessible by removing the need to build the artifacts if users wish. 

For my use case, this will allow me to add the language server to [Homebrew](https://brew.sh).

Because the workflow is triggered on tags prepended with `v`, for instance `v1.2.3`. I can see that there aren't any tags in the repo, so let me know if that's not an option and perhaps we could discuss a path forward :)

*Testing*

See my [run of the deploy job](https://github.com/RenFraser/smithy-language-server/actions/runs/4517612098/jobs/7956939050) where I pushed tags `vtest` and [associated release](https://github.com/RenFraser/smithy-language-server/releases/tag/vtest)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
