### PR TITLE
Upgrade to Smithy 1.31.0 and update Hover provider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ publishing {
 
 dependencies {
     implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.14.0"
-    implementation "software.amazon.smithy:smithy-model:[1.30.0, 2.0["
+    implementation "software.amazon.smithy:smithy-model:[1.31.0, 2.0["
     implementation 'io.get-coursier:interface:1.0.4'
     implementation 'com.disneystreaming.smithy:smithytranslate-formatter-jvm-java-api:0.3.4'
 

--- a/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyTextDocumentService.java
@@ -551,21 +551,21 @@ public class SmithyTextDocumentService implements TextDocumentService {
     }
 
     private String getHoverContentsForShape(Shape shape, Model model) {
-        try {
-            String serializedShape = serializeShape(shape, model);
+        List<ValidationEvent> validationEvents = getValidationEventsForShape(shape);
+        String serializedShape = serializeShape(shape, model);
+        if (validationEvents.isEmpty()) {
             return "```smithy\n" + serializedShape + "\n```";
-        } catch (Exception e) {
-            List<ValidationEvent> validationEvents = getValidationEventsForShape(shape);
-            StringBuilder contents = new StringBuilder();
-            contents.append("Can't display shape ").append("`").append(shape.getId().toString()).append("`:");
-            for (ValidationEvent event : validationEvents) {
-                contents.append(System.lineSeparator()).append(event.getMessage());
-            }
-            if (validationEvents.isEmpty()) {
-                contents.append(System.lineSeparator()).append(e);
-            }
-            return contents.toString();
         }
+        StringBuilder contents = new StringBuilder();
+        contents.append("```smithy\n");
+        contents.append(serializedShape);
+        contents.append("\n");
+        contents.append("---\n");
+        for (ValidationEvent event : validationEvents) {
+            contents.append(event.getSeverity() + ": " + event.getMessage() + "\n");
+        }
+        contents.append("```");
+        return contents.toString();
     }
 
     private String serializeShape(Shape shape, Model model) {

--- a/src/test/java/software/amazon/smithy/lsp/SmithyTextDocumentServiceTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/SmithyTextDocumentServiceTest.java
@@ -214,7 +214,7 @@ public class SmithyTextDocumentServiceTest {
     }
 
     @Test
-    public void hoverOnBrokenShapeShowsErrorMessage() throws Exception {
+    public void hoverOnBrokenShapeAppendsValidations() throws Exception {
         Path baseDir = Paths.get(getClass().getResource("ext/models").toURI());
         String modelFilename = "unknown-trait.smithy";
         Path modelFilePath = baseDir.resolve(modelFilename);
@@ -227,7 +227,10 @@ public class SmithyTextDocumentServiceTest {
             TextDocumentIdentifier tdi = new TextDocumentIdentifier(hs.file(modelFilename).toString());
             Hover hover = tds.hover(hoverParams(tdi, 10, 13)).get();
             MarkupContent hoverContent = hover.getContents().getRight();
-            assertTrue(hoverContent.getValue().startsWith("Can't display shape"));
+            assertEquals(hoverContent.getKind(),"markdown");
+            assertTrue(hoverContent.getValue().startsWith("```smithy"));
+            assertTrue(hoverContent.getValue().contains("structure Foo {}"));
+            assertTrue(hoverContent.getValue().contains("WARNING: Unable to resolve trait `com.external#unknownTrait`"));
         }
     }
 
@@ -553,9 +556,9 @@ public class SmithyTextDocumentServiceTest {
 
             // Resolves via resource read.
             Hover readHover = tds.hover(hoverParams(mainTdi, 76, 12)).get();
-            correctHover(mainHoverPrefix, "@http(\n    method: \"PUT\"\n    uri: \"/bar\"\n    code: 200\n)\n@readonly\n"
-                    + "operation MyOperation {\n    input: MyOperationInput\n    output: MyOperationOutput\n"
-                    + "    errors: [\n        MyError\n    ]\n}", readHover);
+            assertTrue(readHover.getContents().getRight().getValue().contains("@http(\n    method: \"PUT\"\n    "
+                    + "uri: \"/bar\"\n    code: 200\n)\n@readonly\noperation MyOperation {\n    input: "
+                    + "MyOperationInput\n    output: MyOperationOutput\n    errors: [\n        MyError\n    ]\n}"));
 
             // Does not correspond to shape.
             Hover noMatchHover = tds.hover(hoverParams(mainTdi, 0, 0)).get();
@@ -666,9 +669,9 @@ public class SmithyTextDocumentServiceTest {
 
             // Resolves via resource read.
             Hover readHover = tds.hover(hoverParams(mainTdi, 78, 12)).get();
-            correctHover(mainHoverPrefix, "@http(\n    method: \"PUT\"\n    uri: \"/bar\"\n    code: 200\n)\n@readonly\n"
-                    + "operation MyOperation {\n    input: MyOperationInput\n    output: MyOperationOutput\n"
-                    + "    errors: [\n        MyError\n    ]\n}", readHover);
+            assertTrue(readHover.getContents().getRight().getValue().contains("@http(\n    method: \"PUT\"\n    "
+                    + "uri: \"/bar\"\n    code: 200\n)\n@readonly\noperation MyOperation {\n    input: "
+                    + "MyOperationInput\n    output: MyOperationOutput\n    errors: [\n        MyError\n    ]\n}"));
 
             // Does not correspond to shape.
             Hover noMatchHover = tds.hover(hoverParams(mainTdi, 0, 0)).get();


### PR DESCRIPTION
Upgrades the Language Server to use 1.31.0.

The Hover provider uses [SmithyIdlModelSerializer](https://github.com/awslabs/smithy/blob/main/smithy-model/src/main/java/software/amazon/smithy/model/shapes/SmithyIdlModelSerializer.java) to generate a serialized preview of the target shape. Previously, if the target shape had validation, the serializer would throw an exception. Beginning with 1.31.0, the serializer is able to successfully serialize these shapes.

This PR updates the Hover provider to append validation events to the returned hover content.

In the attached screenshot, the target `Foo` shape is being hovered over within the `Bar` structure. `Foo`, defined in foo.smithy, has an unknown trait applied and the hover now shows the serialized shape, along with the validation `WARNING` about the unknown trait that has been applied to that shape.

![hover](https://user-images.githubusercontent.com/782571/235504547-c8d60774-dd6d-42ff-803a-bba9269dc9f3.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
