### PR TITLE
More verbosity in logs/output panel in case of errors

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -82,7 +82,7 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
         tempWorkspaceRoot.deleteOnExit();
         WorkspaceFolder workspaceFolder = new WorkspaceFolder(tempWorkspaceRoot.toURI().toString());
         params.setWorkspaceFolders(ListUtils.of(workspaceFolder));
-      } catch (Exception e) {
+      } catch (IOException e) {
         e.printStackTrace();
       }
     }

--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -69,7 +69,7 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
         loadSmithyBuild(workspaceRoot);
       } catch (Exception e) {
         LspLog.println("Failure trying to load extensions from workspace root: " + workspaceRoot.getAbsolutePath());
-        LspLog.println(e.toString());
+        e.printStackTrace();
       }
     } else {
       LspLog.println("Workspace root was null");
@@ -78,11 +78,11 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
     if (params.getWorkspaceFolders() == null) {
       try {
         tempWorkspaceRoot = Files.createTempDirectory("smithy-lsp-workspace").toFile();
-        System.out.println("Created temporary workspace root: " + tempWorkspaceRoot);
+        LspLog.println("Created temporary workspace root: " + tempWorkspaceRoot);
         tempWorkspaceRoot.deleteOnExit();
         WorkspaceFolder workspaceFolder = new WorkspaceFolder(tempWorkspaceRoot.toURI().toString());
         params.setWorkspaceFolders(ListUtils.of(workspaceFolder));
-      } catch (IOException e) {
+      } catch (Exception e) {
         e.printStackTrace();
       }
     }
@@ -95,6 +95,7 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
         loadSmithyBuild(root);
       } catch (Exception e) {
         LspLog.println("Error when loading workspace folder " + ws.toString() + ": " + e);
+        e.printStackTrace();
       }
     }
 

--- a/src/main/java/software/amazon/smithy/lsp/ext/FileCachingCollector.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/FileCachingCollector.java
@@ -63,7 +63,12 @@ final class FileCachingCollector implements ShapeLocationCollector {
         this.membersToUpdateMap = new HashMap<>();
 
         for (ModelFile modelFile : this.fileCache.values()) {
-            collectContainerShapeLocationsInModelFile(modelFile);
+            try {
+                collectContainerShapeLocationsInModelFile(modelFile);
+            } catch (Exception e) {
+                throw new RuntimeException("Exception while collecting container shape locations in model file: "
+                        + modelFile.filename, e);
+            }
         }
 
         operationsWithInlineInputOutputMap.forEach((this::collectInlineInputOutputLocations));

--- a/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/SmithyProject.java
@@ -172,7 +172,13 @@ public final class SmithyProject {
             return Either.forLeft(model.getLeft());
         } else {
             model.getRight().getValidationEvents().forEach(LspLog::println);
-            return Either.forRight(new SmithyProject(imports, smithyFiles, externalJars, root, model.getRight()));
+
+            try {
+                SmithyProject p = new SmithyProject(imports, smithyFiles, externalJars, root, model.getRight());
+                return Either.forRight(p);
+            } catch (Exception e) {
+                return Either.forLeft(e);
+            }
         }
     }
 


### PR DESCRIPTION
*Description of changes:*

While fighting some issues in a project not loading (recently seeing some similar to #100), I found that we were discarding some useful information, such as stack traces, which makes it more difficult to debug issues on remote machines (such as my colleagues').

This PR adds more `e.printStackTrace()` in cases where we only printed the exception _messages_. While this isn't perfect, and it's far from ideal UX when you see potentially duplicate stack traces, I find that in this case more is better than none.

Many of the issues I'm seeing anytime something goes wrong in loading a project are NPEs on the `project` field in `SmithyTextDocumentService`, so I also marked that as nullable to make it clearer that it's not a safe field to use in all cases. We can amend the usages of that field in future PRs so that they have reasonable fallbacks.

Example of what would happen after this change given some issue in `FileCachingCollector` (responsible for things like #100):

<img width="2478" alt="image" src="https://github.com/awslabs/smithy-language-server/assets/894884/cea972dd-7d30-4ad1-b751-f5e7afe4b21e">

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
