### PR TITLE
Fix matching inline inputs/outputs with operations

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/ext/FileCachingCollector.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/FileCachingCollector.java
@@ -239,9 +239,12 @@ final class FileCachingCollector implements ShapeLocationCollector {
         ) {
             String suffix = getOperationInputOrOutputSuffix(shape, preamble);
             String shapeName = shape.getId().getName();
+
             String matchingOperationName = shapeName.substring(0, shapeName.length() - suffix.length());
+            ShapeId matchingOperationId = ShapeId.fromParts(shape.getId().getNamespace(), matchingOperationName);
+
             return model.shapes(OperationShape.class)
-                    .filter(operationShape -> operationShape.getId().getName().equals(matchingOperationName))
+                    .filter(operationShape -> operationShape.getId().equals(matchingOperationId))
                     .findFirst()
                     .filter(operation -> shapeWasDefinedInline(operation, shape, modelFile));
         }

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
@@ -161,8 +161,8 @@ public class SmithyProjectTest {
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
             Map<ShapeId, Location> locationMap = hs.getProject().getLocations();
 
-            correctLocation(locationMap, "a#HelloWorld", 4, 0, 13,  1);
-            correctLocation(locationMap, "b#HelloWorld", 6, 0, 15,  1);
+            correctLocation(locationMap, "a#HelloWorld", 4, 0, 13, 1);
+            correctLocation(locationMap, "b#HelloWorld", 6, 0, 15, 1);
         }
     }
 

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
@@ -150,6 +150,7 @@ public class SmithyProjectTest {
     }
 
     // https://github.com/awslabs/smithy-language-server/issues/110
+    // Note: This test is flaky, it may succeed even if the code being tested is incorrect.
     @Test
     public void handlesSameOperationNameBetweenNamespaces() throws Exception {
         Path baseDir = Paths.get(SmithyProjectTest.class.getResource("models/operation-name-conflict").toURI());
@@ -160,7 +161,8 @@ public class SmithyProjectTest {
         try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
             Map<ShapeId, Location> locationMap = hs.getProject().getLocations();
 
-            assertNotNull(locationMap.get(ShapeId.from("b#HelloWorld")));
+            correctLocation(locationMap, "a#HelloWorld", 4, 0, 13,  1);
+            correctLocation(locationMap, "b#HelloWorld", 6, 0, 15,  1);
         }
     }
 

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
@@ -149,6 +149,21 @@ public class SmithyProjectTest {
         }
     }
 
+    // https://github.com/awslabs/smithy-language-server/issues/110
+    @Test
+    public void handlesSameOperationNameBetweenNamespaces() throws Exception {
+        Path baseDir = Paths.get(SmithyProjectTest.class.getResource("models/operation-name-conflict").toURI());
+        Path modelA = baseDir.resolve("a.smithy");
+        Path modelB = baseDir.resolve("b.smithy");
+        List<Path> modelFiles = ListUtils.of(modelA, modelB);
+
+        try (Harness hs = Harness.create(SmithyBuildExtensions.builder().build(), modelFiles)) {
+            Map<ShapeId, Location> locationMap = hs.getProject().getLocations();
+
+            assertNotNull(locationMap.get(ShapeId.from("b#HelloWorld")));
+        }
+    }
+
     @Test
     public void definitionLocationsV1() throws Exception {
         Path baseDir = Paths.get(SmithyProjectTest.class.getResource("models/v1").toURI());

--- a/src/test/resources/software/amazon/smithy/lsp/ext/models/operation-name-conflict/a.smithy
+++ b/src/test/resources/software/amazon/smithy/lsp/ext/models/operation-name-conflict/a.smithy
@@ -1,0 +1,14 @@
+$version: "2"
+
+namespace a
+
+operation HelloWorld {
+    input := {
+        @required
+        name: String
+    }
+    output := {
+        @required
+        name: String
+    }
+}

--- a/src/test/resources/software/amazon/smithy/lsp/ext/models/operation-name-conflict/b.smithy
+++ b/src/test/resources/software/amazon/smithy/lsp/ext/models/operation-name-conflict/b.smithy
@@ -1,0 +1,16 @@
+$version: "2"
+
+namespace b
+
+string Ignored
+
+operation HelloWorld {
+    input := {
+        @required
+        name: String
+    }
+    output := {
+        @required
+        name: String
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* #110

*Description of changes:*

This fixes #110 (an IIOBE) by preventing the underlying issue: the `FileCachingCollector` mixing up operations with the same name in different namespaces.

Unfortunately, the test that reproduced the issue is flaky, as it would only fail about half the time before the fix was added - I think there's some non-deterministic behavior in some part of the collector that affects the order of things being collected, and sometimes prevents exhibiting the incorrect behavior. I've confirmed that it reliably passes now after the fix was applied.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
